### PR TITLE
Increase coverage for redis commands server class

### DIFF
--- a/aioredis/commands/server.py
+++ b/aioredis/commands/server.py
@@ -16,12 +16,18 @@ class ServerCommandsMixin:
     def bgrewriteaof(self):
         """Asynchronously rewrite the append-only file."""
         fut = self.execute(b'BGREWRITEAOF')
-        return wait_ok(fut)
+        return wait_ok(
+            fut,
+            expected="Background append only file rewriting started"
+        )
 
     def bgsave(self):
         """Asynchronously save the dataset to disk."""
         fut = self.execute(b'BGSAVE')
-        return wait_ok(fut)
+        return wait_ok(
+            fut,
+            expected="Background saving started"
+        )
 
     def client_kill(self):
         """Kill the connection of a client.

--- a/aioredis/util.py
+++ b/aioredis/util.py
@@ -64,11 +64,14 @@ def decode(obj, encoding):
 
 
 @asyncio.coroutine
-def wait_ok(fut):
+def wait_ok(fut, expected=None):
     res = yield from fut
-    if res in (b'QUEUED', 'QUEUED'):
+    if expected:
+        return res in (expected.encode(), expected)
+    elif res in (b'QUEUED', 'QUEUED'):
         return res
-    return res in (b'OK', 'OK')
+    else:
+        return res in (b'OK', 'OK')
 
 
 @asyncio.coroutine


### PR DESCRIPTION
For those methods that can't be tested in a deterministic way using a real connection Redis, just patched and asserting the calls made to the underlying `execute` function.

It should help to pass PR like this https://github.com/aio-libs/aioredis/pull/245