### PR TITLE
checking if reader is None

### DIFF
--- a/aioredis/connection.py
+++ b/aioredis/connection.py
@@ -196,7 +196,10 @@ class RedisConnection(AbcConnection):
                 last_error = exc
                 break
             else:
-                if (obj == b'' or obj is None) and self._reader.at_eof():
+                if (
+                    (obj == b'' or obj is None) and
+                    (self._reader is None or self._reader.at_eof())
+                ):
                     logger.debug("Connection has been closed by server,"
                                  " response: %r", obj)
                     last_error = ConnectionClosedError("Reader at end of file")


### PR DESCRIPTION
Getting errors when connection was closed:
```
  File "/usr/local/lib/python3.6/site-packages/tornado/gen.py", line 1069, in run
    yielded = self.gen.send(value)
  File "<string>", line 6, in _wrap_awaitable
  File "/usr/local/lib/python3.6/site-packages/cian_core/context/_stack_context.py", line 70, in wrapper
    val = yielded.send(res)
  File "/usr/local/lib/python3.6/site-packages/aioredis/connection.py", line 199, in _read_data
    if (obj == b'' or obj is None) and self._reader.at_eof():
AttributeError: 'NoneType' object has no attribute 'at_eof'
```