### PR TITLE
Fix bug with waiting for a blocking operation

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -12,7 +12,6 @@ Changes
 * Reduce ``encode_command()`` cost about 60%
   (see `#397 <https://github.com/aio-libs/aioredis/pull/397>`_);
 
-
 **FIX**:
 
 * Fix pipeline commands buffering was causing multiple ``sendto`` syscalls
@@ -30,6 +29,9 @@ Changes
 
 * Fix bug in ``ConnectionsPool._drop_closed`` method
   (see `#461 <https://github.com/aio-libs/aioredis/pull/461>`_);
+
+* Fix hanging in specific scenario with long-blocking operations
+  (see `#575 <https://github.com/aio-libs/aioredis/pull/575>`_);
 
 **MISC**:
 

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -36,4 +36,5 @@ Taku Fukada
 Taras Voinarovskyi
 Thanos Lefteris
 Thomas Steinacher
+Tigran Saluev
 Volodymyr Hotsyk

--- a/aioredis/pool.py
+++ b/aioredis/pool.py
@@ -192,7 +192,8 @@ class ConnectionsPool(AbcPool):
         """
         conn, address = self.get_connection(command, args)
         if conn is not None:
-            fut = asyncio.ensure_future(self._execute_with_conn(conn, command, *args, **kw), loop=self._loop)
+            coro = self._execute_with_conn(conn, command, *args, **kw)
+            fut = asyncio.ensure_future(coro, loop=self._loop)
             return self._check_result(fut, command, args, kw)
         else:
             coro = self._wait_execute(address, command, args, kw)

--- a/tests/pool_test.py
+++ b/tests/pool_test.py
@@ -341,8 +341,10 @@ async def test_select_free_connection(create_pool, loop, server):
         await pool.execute("rpush", "somequeue", 42, 100500)
         blpop = pool.execute("blpop", "someotherqueue", 0)
         await pool.execute("blpop", "somequeue", 0)
-        # At this point, one of connections should already be released and used immediately.
+        # At this point, one of connections should already
+        # be released and used immediately.
         await pool.execute("blpop", "somequeue", 0)
+        blpop.cancel()
 
 
 @pytest.mark.run_loop


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

While developing my application, I encountered an interesting effect that some of my non-blocking operations were hanging while the connections limit was big enough for them to work instantly. I dug deeper into the code and discovered that at some point my operation was being scheduled to a connection taken by a blocking operation previously (application's main thread was listening to a queue with BLPOP, spawning new coroutines for every item), despite there still were free connections (released after previous non-blocking operations).

I added a test reproducing this behavior (failing on current version of aioredis) and fixed the code to make it pass, all the other tests remaining intact. As a bonus, I ripped out the O(N) `_pool.remove()` call.

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

No.
<!-- Outline any notable behaviour for the end users. -->