### PR TITLE
In tests accept connection string from command line

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -130,6 +130,19 @@ def redis(create_redis, server, loop):
 
 
 @pytest.fixture
+def redis_url(request):
+    return request.config.getoption("--redis-url")
+
+@pytest.fixture
+def redis_(create_redis, loop, redis_url):
+    """Returns Redis client instance."""
+    redis = loop.run_until_complete(
+        create_redis(redis_url, loop=loop))
+    loop.run_until_complete(redis.flushall())
+    return redis
+
+
+@pytest.fixture
 def redis_sentinel(create_sentinel, sentinel, loop):
     """Returns Redis Sentinel client instance."""
     redis_sentinel = loop.run_until_complete(
@@ -210,6 +223,10 @@ def pytest_addoption(parser):
     parser.addoption('--redis-server', default=[],
                      action="append",
                      help="Path to redis-server executable,"
+                          " defaults to `%(default)s`")
+    parser.addoption('--redis-url', default='redis://localhost:6379/0',
+                     action="store",
+                     help="Redis connection string,"
                           " defaults to `%(default)s`")
     parser.addoption('--ssl-cafile', default='tests/ssl/cafile.crt',
                      help="Path to testing SSL CA file")

--- a/tests/string_commands_test.py
+++ b/tests/string_commands_test.py
@@ -232,6 +232,12 @@ async def test_get(redis):
     with pytest.raises(TypeError):
         await redis.get(None)
 
+@pytest.mark.run_loop
+async def test_get(redis_):
+    await add(redis_, 'my-key', 'value')
+    ret = await redis_.get('my-key')
+    assert ret == b'value'
+
 
 @pytest.mark.run_loop
 async def test_getbit(redis):


### PR DESCRIPTION
This PR is created as a basis for discussion ( but can become a "Work in progress" :wink:  )

I wanted to test `aioredis` against different versions of `Redis` and couldn't find a way to do so. 
I mean, it is not easy to install one particular patch version of redis, let alone several. 

So I've added `--redis-url` cmdline option to use like so:
```text
$ pytest tests/string_commands_test.py::test_get -sq --redis-url="redis://localhost:6371"                                                                                                          
..
2 passed in 0.06 seconds
```
For this to work there should also be redis-server somewhere, e.g.:
```bash
$ docker run --rm -p 6371:6379 redis:5.0.3
```

Please let me know what you think.
And maybe there is a proper (simpler) way to test the lib against different versions of `Redis`, please let me know.


P.S. I have even drawn this doodle to understand what-goes-where, but no luck
![image](https://user-images.githubusercontent.com/10965580/57323290-34c02800-710e-11e9-8906-1b0f4a0fa1bb.png)
