### PR TITLE
Added compatibility with Redis ACL, using AUTH command with username and passsword.

### DIFF
--- a/aioredis/commands/__init__.py
+++ b/aioredis/commands/__init__.py
@@ -91,12 +91,12 @@ class Redis(GenericCommandsMixin, StringCommandsMixin,
         """True if connection is closed."""
         return self._pool_or_conn.closed
 
-    def auth(self, password):
+    def auth(self, username, password):
         """Authenticate to server.
 
         This method wraps call to :meth:`aioredis.RedisConnection.auth()`
         """
-        return self._pool_or_conn.auth(password)
+        return self._pool_or_conn.auth(username, password)
 
     def echo(self, message, *, encoding=_NOTSET):
         """Echo the given string."""

--- a/aioredis/sentinel/commands.py
+++ b/aioredis/sentinel/commands.py
@@ -5,7 +5,7 @@ from ..commands import Redis
 from .pool import create_sentinel_pool
 
 
-async def create_sentinel(sentinels, *, db=None, password=None,
+async def create_sentinel(sentinels, *, db=None, username=None, password=None,
                           encoding=None, minsize=1, maxsize=10,
                           ssl=None, timeout=0.2, loop=None):
     """Creates Redis Sentinel client.
@@ -18,6 +18,7 @@ async def create_sentinel(sentinels, *, db=None, password=None,
 
     pool = await create_sentinel_pool(sentinels,
                                       db=db,
+                                      username=username,
                                       password=password,
                                       encoding=encoding,
                                       minsize=minsize,

--- a/aioredis/sentinel/pool.py
+++ b/aioredis/sentinel/pool.py
@@ -24,7 +24,7 @@ _NON_DISCOVERED = object()
 _logger = sentinel_logger.getChild('monitor')
 
 
-async def create_sentinel_pool(sentinels, *, db=None, password=None,
+async def create_sentinel_pool(sentinels, *, db=None, username=None, password=None,
                                encoding=None, minsize=1, maxsize=10,
                                ssl=None, parser=None, timeout=0.2, loop=None):
     """Create SentinelPool."""
@@ -35,6 +35,7 @@ async def create_sentinel_pool(sentinels, *, db=None, password=None,
     #     loop = asyncio.get_event_loop()
 
     pool = SentinelPool(sentinels, db=db,
+                        username=username,
                         password=password,
                         ssl=ssl,
                         encoding=encoding,
@@ -54,7 +55,7 @@ class SentinelPool:
     as well as services' connections.
     """
 
-    def __init__(self, sentinels, *, db=None, password=None, ssl=None,
+    def __init__(self, sentinels, *, db=None, username=None, password=None, ssl=None,
                  encoding=None, parser=None, minsize, maxsize, timeout,
                  loop=None):
         # TODO: deprecation note
@@ -72,6 +73,7 @@ class SentinelPool:
         self._slaves = {}
         self._parser_class = parser
         self._redis_db = db
+        self._redis_username = username
         self._redis_password = password
         self._redis_ssl = ssl
         self._redis_encoding = encoding
@@ -120,6 +122,7 @@ class SentinelPool:
             self._masters[service] = ManagedPool(
                 self, service, is_master=True,
                 db=self._redis_db,
+                username=self._redis_username,
                 password=self._redis_password,
                 encoding=self._redis_encoding,
                 minsize=self._redis_minsize,
@@ -136,6 +139,7 @@ class SentinelPool:
             self._slaves[service] = ManagedPool(
                 self, service, is_master=False,
                 db=self._redis_db,
+                username=self._redis_username,
                 password=self._redis_password,
                 encoding=self._redis_encoding,
                 minsize=self._redis_minsize,
@@ -379,10 +383,10 @@ class SentinelPool:
 class ManagedPool(ConnectionsPool):
 
     def __init__(self, sentinel, service, is_master,
-                 db=None, password=None, encoding=None, parser=None,
+                 db=None, username=None, password=None, encoding=None, parser=None,
                  *, minsize, maxsize, ssl=None, loop=None):
         super().__init__(_NON_DISCOVERED,
-                         db=db, password=password, encoding=encoding,
+                         db=db, username=username, password=password, encoding=encoding,
                          minsize=minsize, maxsize=maxsize, ssl=ssl,
                          parser=parser, loop=loop)
         assert self._address is _NON_DISCOVERED


### PR DESCRIPTION
## What do these changes do?

* Added support for Redis ACL, by adding optional username parameter throughout the various connection classes.
* `RedisConnection.auth` method updated to accept username and password.
* With this patch, I'm able to successfully use Redis ACL username+password via `aioredis.create_sentinel()`.
* URI-based parsing/connection (with username) has not been tested.

## Are there changes in behavior for the user?

* `RedisConnection.auth()` parameters updated to take both username and password, rather than just password. If username given, then an AUTH command is issued with username and password; otherwise, an AUTH command is issued with just password. Not sure if this lower level API is meant to be used by user code, but if so then this is backwards incompatible.

## Related issue number

#818

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is `<Name> <Surname>`.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new news fragment into the [`CHANGES/`](../tree/master/CHANGES) folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example:
   `Fix issue with non-ascii contents in doctest text files.`
