### PR TITLE
KEEPTTL in set()

### DIFF
--- a/aioredis/commands/string.py
+++ b/aioredis/commands/string.py
@@ -196,7 +196,7 @@ class StringCommandsMixin:
             args.append(b"NX")
 
         """
-        ``keepttl`` if True, retain the time to live associated with the key.
+        keepttl if True, retain the time to live associated with the key.
             (Available since Redis 6.0)
         """
         if keepttl:

--- a/aioredis/commands/string.py
+++ b/aioredis/commands/string.py
@@ -174,7 +174,7 @@ class StringCommandsMixin:
         fut = self.execute(b"PSETEX", key, milliseconds, value)
         return wait_ok(fut)
 
-    def set(self, key, value, *, expire=0, pexpire=0, exist=None):
+    def set(self, key, value, *, expire=0, pexpire=0, exist=None, keepttl=False):
         """Set the string value of a key.
 
         :raises TypeError: if expire or pexpire is not int
@@ -194,6 +194,14 @@ class StringCommandsMixin:
             args.append(b"XX")
         elif exist is self.SET_IF_NOT_EXIST:
             args.append(b"NX")
+
+        """
+        ``keepttl`` if True, retain the time to live associated with the key.
+            (Available since Redis 6.0)
+        """
+        if keepttl:
+            args.append('KEEPTTL')
+
         fut = self.execute(b"SET", key, value, *args)
         return wait_ok(fut)
 

--- a/aioredis/commands/string.py
+++ b/aioredis/commands/string.py
@@ -200,7 +200,7 @@ class StringCommandsMixin:
             (Available since Redis 6.0)
         """
         if keepttl:
-            args.append('KEEPTTL')
+            args.append(b"KEEPTTL")
 
         fut = self.execute(b"SET", key, value, *args)
         return wait_ok(fut)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?
keepttl in set()

``keepttl`` if True, retain the time to live associated with the key.
            (Available since Redis 6.0)

## Are there changes in behavior for the user?

No, optional parameter only.

## Related issue number

No.