### PR TITLE
Fix async_timeout not awaited (Fixes #923)

### DIFF
--- a/aioredis/connection.py
+++ b/aioredis/connection.py
@@ -677,7 +677,7 @@ class Connection:
 
     async def _connect(self):
         """Create a TCP socket connection"""
-        with async_timeout.timeout(self.socket_connect_timeout):
+        async with async_timeout.timeout(self.socket_connect_timeout):
             reader, writer = await asyncio.open_connection(
                 host=self.host, port=self.port, ssl=self.ssl_context, loop=self._loop
             )


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Async timeout should be properly awaited.

## Are there changes in behavior for the user?

This should fix a bug

## Related issue number

Fixes #923 

## Checklist

- [X] I think the code is well written
- [X] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [X] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is `<Name> <Surname>`.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the [`CHANGES/`](../tree/master/CHANGES) folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example:
   `Fix issue with non-ascii contents in doctest text files.`
