### PR TITLE
Use pre-spawned disconnect coro in Connection.__del__

### DIFF
--- a/aioredis/connection.py
+++ b/aioredis/connection.py
@@ -677,7 +677,7 @@ class Connection:
 
     async def _connect(self):
         """Create a TCP socket connection"""
-        with async_timeout.timeout(self.socket_connect_timeout):
+        async with async_timeout.timeout(self.socket_connect_timeout):
             reader, writer = await asyncio.open_connection(
                 host=self.host, port=self.port, ssl=self.ssl_context, loop=self._loop
             )
@@ -844,7 +844,7 @@ class Connection:
     async def read_response(self):
         """Read the response from a previously sent command"""
         try:
-            with async_timeout.timeout(self.socket_timeout):
+            async with async_timeout.timeout(self.socket_timeout):
                 response = await self._parser.read_response()
         except asyncio.TimeoutError:
             await self.disconnect()
@@ -1071,7 +1071,7 @@ class UnixDomainSocketConnection(Connection):  # lgtm [py/missing-call-to-init]
         return pieces
 
     async def _connect(self):
-        with async_timeout.timeout(self._connect_timeout):
+        async with async_timeout.timeout(self._connect_timeout):
             reader, writer = await asyncio.open_unix_connection(path=self.path)
         self._reader = reader
         self._writer = writer

--- a/aioredis/connection.py
+++ b/aioredis/connection.py
@@ -632,7 +632,7 @@ class Connection:
                 if loop.is_running():
                     loop.create_task(coro)
                 else:
-                    loop.run_until_complete(self.disconnect())
+                    loop.run_until_complete(coro)
         except Exception:
             pass
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -131,11 +131,12 @@ def create_redis(request, event_loop):
     single_connection = request.param
 
     async def f(url: str = request.config.getoption("--redis-url"), **kwargs):
+        single = kwargs.pop("single_connection_client", False) or single_connection
         url_options = parse_url(url)
         url_options.update(kwargs)
         pool = aioredis.ConnectionPool(**url_options)
         client: aioredis.Redis = aioredis.Redis(connection_pool=pool)
-        if single_connection:
+        if single:
             client = client.client()
             await client.initialize()
 

--- a/tests/test_multiprocessing.py
+++ b/tests/test_multiprocessing.py
@@ -26,9 +26,8 @@ class TestMultiprocessing:
     # use a multi-connection client as that's the only type that is
     # actually fork/process-safe
     @pytest.fixture()
-    async def r(self, create_redis, server):
+    async def r(self, create_redis):
         redis = await create_redis(
-            server.tcp_address,
             single_connection_client=False,
         )
         yield redis

--- a/tests/test_sentinel.py
+++ b/tests/test_sentinel.py
@@ -66,15 +66,13 @@ class SentinelTestCluster:
 
 
 @pytest.fixture()
-def cluster(request, master_ip):
-    def teardown():
-        aioredis.sentinel.Redis = saved_Redis
+async def cluster(master_ip):
 
     cluster = SentinelTestCluster(ip=master_ip)
     saved_Redis = aioredis.sentinel.Redis
     aioredis.sentinel.Redis = cluster.client
-    request.addfinalizer(teardown)
-    return cluster
+    yield cluster
+    aioredis.sentinel.Redis = saved_Redis
 
 
 @pytest.fixture()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

This prevents a leaked coroutine when the Connection is garbage-collected.

## Are there changes in behavior for the user?

No

## Related issue number

resolves #923 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is `<Name> <Surname>`.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the [`CHANGES/`](../tree/master/CHANGES) folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example:
   `Fix issue with non-ascii contents in doctest text files.`
