### PR TITLE
Disable uvloop py3.6 combo in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,8 @@ jobs:
         exclude:
         - { pyver: pypy3, uvloop: uvloop, os: ubuntu-latest, redis: 5.0.10 }
         - { pyver: pypy3, uvloop: uvloop, os: ubuntu-latest, redis: 6.0.10 }
+        - { pyver: 3.6, uvloop: uvloop, os: ubuntu-latest, redis: 5.0.10 }
+        - { pyver: 3.6, uvloop: uvloop, os: ubuntu-latest, redis: 6.0.10 }
       fail-fast: false
     services:
       redis:


### PR DESCRIPTION
## What do these changes do?

Disables the combination of uvloop with Python 3.6 due to https://github.com/MagicStack/uvloop/blob/c808a663b297bb2aee745523c277d6fafecebbeb/setup.py#L5

For some reason, the tests continue, but this should be an error. This was due to the GitHub action at https://github.com/aio-libs/aioredis-py/actions/runs/677918070 but it doesn't explain why everything runs for > 15 minutes

## Are there changes in behavior for the user?

No

## Related issue number

No