### PR TITLE
fix ssl argument in _connect method

### DIFF
--- a/aioredis/connection.py
+++ b/aioredis/connection.py
@@ -679,7 +679,7 @@ class Connection:
         """Create a TCP socket connection"""
         async with async_timeout.timeout(self.socket_connect_timeout):
             reader, writer = await asyncio.open_connection(
-                host=self.host, port=self.port, ssl=self.ssl_context, loop=self._loop
+                host=self.host, port=self.port, ssl=self.ssl_context.get(), loop=self._loop
             )
         self._reader = reader
         self._writer = writer

--- a/aioredis/connection.py
+++ b/aioredis/connection.py
@@ -681,7 +681,7 @@ class Connection:
             reader, writer = await asyncio.open_connection(
                 host=self.host,
                 port=self.port,
-                ssl=self.ssl_context.get(),
+                ssl=self.ssl_context.get() if self.ssl_context else None,
                 loop=self._loop,
             )
         self._reader = reader

--- a/aioredis/connection.py
+++ b/aioredis/connection.py
@@ -679,7 +679,10 @@ class Connection:
         """Create a TCP socket connection"""
         async with async_timeout.timeout(self.socket_connect_timeout):
             reader, writer = await asyncio.open_connection(
-                host=self.host, port=self.port, ssl=self.ssl_context.get(), loop=self._loop
+                host=self.host,
+                port=self.port,
+                ssl=self.ssl_context.get(),
+                loop=self._loop,
             )
         self._reader = reader
         self._writer = writer


### PR DESCRIPTION
asyncio.open_connection requires SSLContext as ssl argument, but RedisSSLContext given. RedisSSLContext has .get() method, which produces SSLContext object. Using this method to provide right argument
