### PR TITLE
Allow ssl connection to redis when use sentinel

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,14 +44,14 @@ Benchmarks can be found here:
 ## Contribute
 
 -   Issue Tracker: <https://github.com/aio-libs/aioredis/issues>
--   Google Group: <https://groups.google.com/forum/>\#!forum/aio-libs
+-   Google Group: <https://groups.google.com/g/aio-libs>
 -   Gitter: <https://gitter.im/aio-libs/Lobby>
 -   Source Code: <https://github.com/aio-libs/aioredis>
--   Contributor's guide: devel
+-   Contributor's guide: [devel](docs/devel.md)
 
 Feel free to file an issue or make pull request if you find any bugs or
 have some suggestions for library improvement.
 
 ## License
 
-The aioredis is offered under a [MIT License](license.md).
+The aioredis is offered under a [MIT License](LICENSE).

--- a/aioredis/sentinel.py
+++ b/aioredis/sentinel.py
@@ -3,7 +3,7 @@ import weakref
 from typing import AsyncIterator, Iterable, Mapping, Sequence, Tuple, Type
 
 from aioredis.client import Redis
-from aioredis.connection import Connection, ConnectionPool, EncodableT, SSLConnection
+from aioredis.connection import ConnectionPool, EncodableT, SSLConnection
 from aioredis.exceptions import (
     ConnectionError,
     ReadOnlyError,
@@ -21,7 +21,16 @@ class SlaveNotFoundError(ConnectionError):
     pass
 
 
-class SentinelManagedConnection:
+class SentinelManagedConnection(SSLConnection):
+    def __init__(self, **kwargs):
+        self.connection_pool = kwargs.pop("connection_pool")
+        if not kwargs.pop("ssl", False):
+            # use constructor from Connection class
+            super(SSLConnection, self).__init__(**kwargs)
+        else:
+            # use constructor from SSLConnection class
+            super().__init__(**kwargs)
+
     def __repr__(self):
         pool = self.connection_pool
         s = f"{self.__class__.__name__}<service={pool.service_name}"
@@ -66,18 +75,6 @@ class SentinelManagedConnection:
             raise
 
 
-class SentinelManagedSSLConnection(SentinelManagedConnection, SSLConnection):
-    def __init__(self, **kwargs):
-        self.connection_pool = kwargs.pop("connection_pool")
-        super().__init__(**kwargs)
-
-
-class SentinelManagedPlaneConnection(SentinelManagedConnection, Connection):
-    def __init__(self, **kwargs):
-        self.connection_pool = kwargs.pop("connection_pool")
-        super().__init__(**kwargs)
-
-
 class SentinelConnectionPool(ConnectionPool):
     """
     Sentinel backed connection pool.
@@ -88,10 +85,7 @@ class SentinelConnectionPool(ConnectionPool):
 
     def __init__(self, service_name, sentinel_manager, **kwargs):
         kwargs["connection_class"] = kwargs.get(
-            "connection_class",
-            SentinelManagedPlaneConnection
-            if not kwargs.pop("ssl", False)
-            else SentinelManagedSSLConnection,
+            "connection_class", SentinelManagedConnection
         )
         self.is_master = kwargs.pop("is_master", True)
         self.check_connection = kwargs.pop("check_connection", False)

--- a/aioredis/sentinel.py
+++ b/aioredis/sentinel.py
@@ -3,7 +3,7 @@ import weakref
 from typing import AsyncIterator, Iterable, Mapping, Sequence, Tuple, Type
 
 from aioredis.client import Redis
-from aioredis.connection import Connection, ConnectionPool, EncodableT
+from aioredis.connection import Connection, ConnectionPool, EncodableT, SSLConnection
 from aioredis.exceptions import (
     ConnectionError,
     ReadOnlyError,
@@ -21,11 +21,7 @@ class SlaveNotFoundError(ConnectionError):
     pass
 
 
-class SentinelManagedConnection(Connection):
-    def __init__(self, **kwargs):
-        self.connection_pool = kwargs.pop("connection_pool")
-        super().__init__(**kwargs)
-
+class SentinelManagedConnection:
     def __repr__(self):
         pool = self.connection_pool
         s = f"{self.__class__.__name__}<service={pool.service_name}"
@@ -70,6 +66,18 @@ class SentinelManagedConnection(Connection):
             raise
 
 
+class SentinelManagedSSLConnection(SentinelManagedConnection, SSLConnection):
+    def __init__(self, **kwargs):
+        self.connection_pool = kwargs.pop("connection_pool")
+        super().__init__(**kwargs)
+
+
+class SentinelManagedPlaneConnection(SentinelManagedConnection, Connection):
+    def __init__(self, **kwargs):
+        self.connection_pool = kwargs.pop("connection_pool")
+        super().__init__(**kwargs)
+
+
 class SentinelConnectionPool(ConnectionPool):
     """
     Sentinel backed connection pool.
@@ -80,7 +88,10 @@ class SentinelConnectionPool(ConnectionPool):
 
     def __init__(self, service_name, sentinel_manager, **kwargs):
         kwargs["connection_class"] = kwargs.get(
-            "connection_class", SentinelManagedConnection
+            "connection_class",
+            SentinelManagedPlaneConnection
+            if not kwargs.pop("ssl", False)
+            else SentinelManagedSSLConnection,
         )
         self.is_master = kwargs.pop("is_master", True)
         self.check_connection = kwargs.pop("check_connection", False)


### PR DESCRIPTION



<!-- Thank you for your contribution! -->

This diff allows to pass ssl=True inside **connection_kwargs for Sentinel class to enable ssl connection to redis
Besides enabling functionality itself this change also makes experience with Sentinel() more consistent with Redis()

<!-- Please give a short brief about these changes. -->

Now SentinelManagedConnection enherits from SSLConnection, instead of Connection. 
This allows to populate ssl related properties from SSLConnection class. 
if ssl=True SentinelManagedConnection uses parents constructor (SSLConnection)
If ssl=False SentinelManagedConnection uses grandparents constructor (Connection class)

The only downside of this implementation, is in case ssl=False instance of SentinelManagedConnection has dangling ssl-cert related properties.This properties does not affect behavior in any considerable way.
Afaik there is no obvious way to overcome this issue.

<!-- Outline any notable behaviour for the end users. -->

Users now can pass SSL related attributes to **connection_kwargs in Sentinel class (or alternativelly to master_for or slave_for methods)
