### PR TITLE
Fix codecov paths

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+codecov:
+  disable_default_path_fixes: yes

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [coverage:run]
 branch = true
-source = aioredis,tests
+source = ./aioredis,./tests
 omit = site-packages
 
 [flake8]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [coverage:run]
 branch = true
-source = ./aioredis,./tests
+source = aioredis,tests
 omit = site-packages
 
 [flake8]


### PR DESCRIPTION
Codecov does not pick up on all files, e.g. aioredis/connection.py located at this commit in codecov: https://codecov.io/gh/aio-libs/aioredis-py/tree/b9694797d452bb8d4ca26d2dc14ce73068575130. Resolve via comment in codecov forum: correct fix: https://community.codecov.io/t/codecov-report-missing-files/1928/9 original fix: ~~https://community.codecov.io/t/missing-files-in-codecov-but-not-in-report/825/9~~ 