### PR TITLE
Avoid AttributeError from Pipeline.reset() with a ConnectionError.

### DIFF
--- a/aioredis/client.py
+++ b/aioredis/client.py
@@ -4291,7 +4291,8 @@ class Pipeline(Redis):  # lgtm [py/init-calls-subclass]
                 await self.connection.read_response()
             except ConnectionError:
                 # disconnect will also remove any previous WATCHes
-                await self.connection.disconnect()
+                if self.connection:
+                    await self.connection.disconnect()
         # clean up the other instance attributes
         self.watching = False
         self.explicit_transaction = False


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Avoids an AttributeError from being thrown if in the process of attempting UNWATCH in Pipeline.reset(), the connection is closed and Pipeline.connection is set to None.

## Are there changes in behavior for the user?

No changes.

## Related issue number

No known issue (though I could open one).

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is `<Name> <Surname>`.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the [`CHANGES/`](../tree/master/CHANGES) folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example:
   `Fix issue with non-ascii contents in doctest text files.`
