### PR TITLE
Remove socket timeout setup

### DIFF
--- a/CHANGES/951.bugfix
+++ b/CHANGES/951.bugfix
@@ -1,0 +1,1 @@
+removed socket timeout setup

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -29,6 +29,7 @@ Hugo <hugovk>
 Ihor Gorobets
 Ihor Liubymov
 Ilya Samartsev
+Ivan Antonyuck
 James Hilliard
 Jan Špaček
 Jeff Moser

--- a/aioredis/connection.py
+++ b/aioredis/connection.py
@@ -695,9 +695,6 @@ class Connection:
                     sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
                     for k, v in self.socket_keepalive_options.items():
                         sock.setsockopt(socket.SOL_TCP, k, v)
-                # set the socket_timeout now that we're connected
-                if self.socket_timeout is not None:
-                    sock.settimeout(self.socket_timeout)
 
             except (OSError, TypeError):
                 # `socket_keepalive_options` might contain invalid options


### PR DESCRIPTION
setting timeout on asyncio socket leads to an Exception being thrown

## What do these changes do?

This changes remove settimeout call as suggested by @Andrew-Chen-Wang 

## Are there changes in behavior for the user?

No

## Related issue number

https://github.com/aio-libs/aioredis-py/issues/951#issuecomment-827322087

