### PR TITLE
Update getting-started.md

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -3,7 +3,7 @@
 ## Installation
 
 ```shell
-pip install aioredis
+pip install 'aioredis>=2'
 ```
 
 This will install `aioredis`, `async-timeout`.


### PR DESCRIPTION
The docs don't work for v1, which is currently what pip installs by default

