### PR TITLE
Avoid passing loop= argument where it is deprecated/unneeded

### DIFF
--- a/aioredis/connection.py
+++ b/aioredis/connection.py
@@ -682,7 +682,6 @@ class Connection:
                 host=self.host,
                 port=self.port,
                 ssl=self.ssl_context.get() if self.ssl_context else None,
-                loop=self._loop,
             )
         self._reader = reader
         self._writer = writer
@@ -817,7 +816,6 @@ class Connection:
             await asyncio.wait_for(
                 self._send_packed_command(command),
                 self.socket_timeout,
-                loop=self._loop or asyncio.get_event_loop(),
             )
         except asyncio.TimeoutError:
             await self.disconnect()


### PR DESCRIPTION
## What do these changes do?

Avoids passing explicit loop arguments to `asyncio.wait_for` (where it is deprecated) and `asyncio.open_connection` (where it is still allowed by unneeded within a coroutine).

## Are there changes in behavior for the user?

No

## Related issue number

#1002

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is `<Name> <Surname>`.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the [`CHANGES/`](../tree/master/CHANGES) folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example:
   `Fix issue with non-ascii contents in doctest text files.`
