### PR TITLE
Remove unneeded `loop` arguments

### DIFF
--- a/CHANGES/1002.removal
+++ b/CHANGES/1002.removal
@@ -1,0 +1,2 @@
+Remove explicit loop arguments from connection classes.
+Add loop argument to PubSub.run_in_thread.

--- a/aioredis/connection.py
+++ b/aioredis/connection.py
@@ -682,7 +682,6 @@ class Connection:
                 host=self.host,
                 port=self.port,
                 ssl=self.ssl_context.get() if self.ssl_context else None,
-                loop=self._loop,
             )
         self._reader = reader
         self._writer = writer
@@ -817,7 +816,6 @@ class Connection:
             await asyncio.wait_for(
                 self._send_packed_command(command),
                 self.socket_timeout,
-                loop=self._loop or asyncio.get_event_loop(),
             )
         except asyncio.TimeoutError:
             await self.disconnect()

--- a/aioredis/connection.py
+++ b/aioredis/connection.py
@@ -560,7 +560,6 @@ class Connection:
         "_parser",
         "_connect_callbacks",
         "_buffer_cutoff",
-        "_loop",
         "__dict__",
     )
 
@@ -586,7 +585,6 @@ class Connection:
         client_name: str = None,
         username: str = None,
         encoder_class: Type[Encoder] = Encoder,
-        loop: asyncio.AbstractEventLoop = None,
     ):
         self.pid = os.getpid()
         self.host = host
@@ -612,7 +610,6 @@ class Connection:
         )
         self._connect_callbacks: List[ConnectCallbackT] = []
         self._buffer_cutoff = 6000
-        self._loop = loop
 
     def __repr__(self):
         repr_args = ",".join((f"{k}={v}" for k, v in self.repr_pieces()))
@@ -627,7 +624,7 @@ class Connection:
     def __del__(self):
         try:
             if self.is_connected:
-                loop = self._loop or asyncio.get_event_loop()
+                loop = asyncio.get_event_loop()
                 coro = self.disconnect()
                 if loop.is_running():
                     loop.create_task(coro)
@@ -1049,7 +1046,6 @@ class UnixDomainSocketConnection(Connection):  # lgtm [py/missing-call-to-init]
         socket_read_size: int = 65536,
         health_check_interval: float = 0.0,
         client_name=None,
-        loop: asyncio.AbstractEventLoop = None,
     ):
         self.pid = os.getpid()
         self.path = path
@@ -1068,7 +1064,6 @@ class UnixDomainSocketConnection(Connection):  # lgtm [py/missing-call-to-init]
         self._parser = parser_class(socket_read_size=socket_read_size)
         self._connect_callbacks = []
         self._buffer_cutoff = 6000
-        self._loop = loop
 
     def repr_pieces(self) -> Iterable[Tuple[str, Union[str, int]]]:
         pieces = [
@@ -1271,7 +1266,6 @@ class ConnectionPool:
         self._available_connections: List[Connection]
         self._in_use_connections: Set[Connection]
         self.reset()  # lgtm [py/init-calls-subclass]
-        self.loop = self.connection_kwargs.get("loop")
         self.encoder_class = self.connection_kwargs.get("encoder_class", Encoder)
 
     def __repr__(self):


### PR DESCRIPTION
## What do these changes do?

The new 2.0 implementation has a number of places where it either takes an explicit loop parameter, or passes one to an asyncio function. The need for this was largely removed in Python 3.5.3 (because get_event_loop was changed to return the event loop of the current task when called from inside a task), and many functions (such as wait_for deprecated the parameter in 3.8 with removal for 3.10. Other functions (like open_connection) didn't deprecate it, but made it optional and documented that it is not needed when called from a coroutine. I wouldn't be surprised if they are deprecated in future.

## Are there changes in behavior for the user?

Only compared to 2.0.0a1:

1. `__del__` will now always use asyncio.get_event_loop(). But `__del__` is broken anyway, for reasons I've explained in #930.
    
2. PubSub.run_in_thread is a synchronous function but needs to know the event loop to run. I've updated it to take an explicit loop argument. This makes it possible to construct the Redis object before the event loop. I'm going to file a separate issue to remove this function anyway, since aioredis should provide concurrency via asyncio tasks rather than threads, and the one test function has been disabled because it is broken.

## Related issue number

#1002

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is `<Name> <Surname>`.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the [`CHANGES/`](../tree/master/CHANGES) folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example:
   `Fix issue with non-ascii contents in doctest text files.`
