### PR TITLE
Remove py.typed

### DIFF
--- a/CHANGES/1009.misc
+++ b/CHANGES/1009.misc
@@ -1,0 +1,1 @@
+Temporarily remove py.typed because there are errors in the type annotations.

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,6 @@ setup(
     extras_require={
         "hiredis": 'hiredis>=1.0; implementation_name=="cpython"',
     },
-    package_data={"aioredis": ["py.typed"]},
     python_requires=">=3.6",
     include_package_data=True,
 )


### PR DESCRIPTION
## What do these changes do?

This is a temporary workaround for #1008, due to the type annotations
being wrong. The type annotations should eventually be fixed.

## Are there changes in behavior for the user?

Use of aioredis will not be type-checked when running mypy.

## Related issue number

#1008

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is `<Name> <Surname>`.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the [`CHANGES/`](../tree/master/CHANGES) folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example:
   `Fix issue with non-ascii contents in doctest text files.`
