### PR TITLE
Replace PubSub.run_in_thread with coroutine run

### DIFF
--- a/CHANGES/1007.feature
+++ b/CHANGES/1007.feature
@@ -1,0 +1,1 @@
+Replace PubSub.run_in_thread with a coroutine PubSub.run.


### PR DESCRIPTION

<!-- Thank you for your contribution! -->

## What do these changes do?

The port from redis-py brought along PubSub.run_in_thread, and it was
modified to run code on the event loop. However, threading is not the
appropriate concurrency model for aioredis, so I've extracted the logic
and moved it into a `run` coroutine.

Also remove the test that covered run_in_thread and replace it with a
couple of tests for `run`. They're not the strongest tests (just send
and process a single message), but will at least catch simple errors
like missing awaits.

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

Yes, compared to 2.0.0a1. Code using PubSub.run_in_thread will need to be modified to use PubSub.run.
<!-- Outline any notable behaviour for the end users. -->

## Related issue number

#1007 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is `<Name> <Surname>`.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the [`CHANGES/`](../tree/master/CHANGES) folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example:
   `Fix issue with non-ascii contents in doctest text files.`
