### PR TITLE
Use asyncio event loop to get time

### DIFF
--- a/CHANGES/1003.misc
+++ b/CHANGES/1003.misc
@@ -1,0 +1,1 @@
+Get time from event loop.

--- a/aioredis/client.py
+++ b/aioredis/client.py
@@ -4,7 +4,6 @@ import hashlib
 import inspect
 import re
 import threading
-import time
 import time as mod_time
 import warnings
 from itertools import chain
@@ -311,7 +310,7 @@ def sort_return_tuples(response, **options):
     if not response or not options.get("groups"):
         return response
     n = options["groups"]
-    return list(zip(*[response[i::n] for i in range(n)]))
+    return list(zip(*(response[i::n] for i in range(n))))
 
 
 def int_or_none(response):
@@ -3961,7 +3960,10 @@ class PubSub:
                 "did you forget to call subscribe() or psubscribe()?"
             )
 
-        if conn.health_check_interval and time.time() > conn.next_health_check:
+        if (
+            conn.health_check_interval
+            and asyncio.get_event_loop().time() > conn.next_health_check
+        ):
             await conn.send_command(
                 "PING", self.HEALTH_CHECK_MESSAGE, check_health=False
             )

--- a/aioredis/lock.py
+++ b/aioredis/lock.py
@@ -1,3 +1,4 @@
+import asyncio
 import threading
 import time as mod_time
 import uuid
@@ -187,6 +188,7 @@ class Lock:
         object with the default encoding. If a token isn't specified, a UUID
         will be generated.
         """
+        loop = asyncio.get_event_loop()
         sleep = self.sleep
         if token is None:
             token = uuid.uuid1().hex.encode()
@@ -199,14 +201,14 @@ class Lock:
             blocking_timeout = self.blocking_timeout
         stop_trying_at = None
         if blocking_timeout is not None:
-            stop_trying_at = mod_time.monotonic() + blocking_timeout
+            stop_trying_at = loop.time() + blocking_timeout
         while True:
             if await self.do_acquire(token):
                 self.local.token = token
                 return True
             if not blocking:
                 return False
-            next_try_at = mod_time.monotonic() + sleep
+            next_try_at = loop.time() + sleep
             if stop_trying_at is not None and next_try_at > stop_trying_at:
                 return False
             mod_time.sleep(sleep)

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -1,4 +1,4 @@
-import time
+import asyncio
 
 import pytest
 
@@ -104,10 +104,10 @@ class TestLock:
         bt = 0.2
         sleep = 0.05
         lock2 = self.get_lock(r, "foo", sleep=sleep, blocking_timeout=bt)
-        start = time.monotonic()
+        start = asyncio.get_event_loop().time()
         assert not await lock2.acquire()
         # The elapsed duration should be less than the total blocking_timeout
-        assert bt > (time.monotonic() - start) > bt - sleep
+        assert bt > (asyncio.get_event_loop().time() - start) > bt - sleep
         await lock1.release()
 
     async def test_context_manager(self, r):
@@ -129,11 +129,11 @@ class TestLock:
         sleep = 60
         bt = 1
         lock2 = self.get_lock(r, "foo", sleep=sleep, blocking_timeout=bt)
-        start = time.monotonic()
+        start = asyncio.get_event_loop().time()
         assert not await lock2.acquire()
         # the elapsed timed is less than the blocking_timeout as the lock is
         # unattainable given the sleep/blocking_timeout configuration
-        assert bt > (time.monotonic() - start)
+        assert bt > (asyncio.get_event_loop().time() - start)
         await lock1.release()
 
     async def test_releasing_unlocked_lock_raises_error(self, r):

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -14,7 +14,7 @@ pytestmark = pytest.mark.asyncio(forbid_global_loop=True)
 
 
 async def wait_for_message(pubsub, timeout=0.1, ignore_subscribe_messages=False):
-    now = time.time()
+    now = asyncio.get_event_loop().time()
     timeout = now + timeout
     while now < timeout:
         message = await pubsub.get_message(
@@ -23,7 +23,7 @@ async def wait_for_message(pubsub, timeout=0.1, ignore_subscribe_messages=False)
         if message is not None:
             return message
         await asyncio.sleep(0.01)
-        now = time.time()
+        now = asyncio.get_event_loop().time()
     return None
 
 


### PR DESCRIPTION
## What do these changes do?

This ensures that all timing uses a consistent (and monotonic) clock. This should probably only get merged if a similar redis-py PR (https://github.com/andymccurdy/redis-py/pull/1491) which switches from time.time to time.monotonic is accepted.

Closes #1003.

## Are there changes in behavior for the user?

No, unless they're mocking time, in which case only one source of time needs mocking (I'm hoping this will work with fakeredis + async-solipsism, but haven't test it yet).

## Related issue number

#1003

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is `<Name> <Surname>`.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the [`CHANGES/`](../tree/master/CHANGES) folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example:
   `Fix issue with non-ascii contents in doctest text files.`
