### PR TITLE
[2.0] Fix aioredis.lock.Lock using a sleep that blocks the event loop

### DIFF
--- a/CHANGES/1016.bugfix
+++ b/CHANGES/1016.bugfix
@@ -1,0 +1,1 @@
+Fix aioredis.lock.Lock using a sleep that blocks the event loop.

--- a/aioredis/lock.py
+++ b/aioredis/lock.py
@@ -1,3 +1,4 @@
+import asyncio
 import threading
 import time as mod_time
 import uuid
@@ -209,7 +210,7 @@ class Lock:
             next_try_at = mod_time.monotonic() + sleep
             if stop_trying_at is not None and next_try_at > stop_trying_at:
                 return False
-            mod_time.sleep(sleep)
+            await asyncio.sleep(sleep)
 
     async def do_acquire(self, token: Union[str, bytes]) -> bool:
         if self.timeout:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Fix aioredis.lock.Lock using a sleep that blocks the event loop.
<!-- Please give a short brief about these changes. -->

No.
## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

#1016

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is `<Name> <Surname>`.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the [`CHANGES/`](../tree/master/CHANGES) folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example:
   `Fix issue with non-ascii contents in doctest text files.`
