### PR TITLE
 Fix min, max args of Z*LEX* to str

### DIFF
--- a/CHANGES/1008.bugfix
+++ b/CHANGES/1008.bugfix
@@ -1,0 +1,1 @@
+Fix type annotations for zrangebylex and similar functions.

--- a/aioredis/client.py
+++ b/aioredis/client.py
@@ -3129,7 +3129,7 @@ class Redis:
         return self.execute_command(*pieces, **options)
 
     def zrangebylex(
-        self, name: str, min: int, max: int, start: int = None, num: int = None
+        self, name: str, min: str, max: str, start: int = None, num: int = None
     ) -> Awaitable:
         """
         Return the lexicographical range of values from sorted set ``name``
@@ -3146,7 +3146,7 @@ class Redis:
         return self.execute_command(*pieces)
 
     def zrevrangebylex(
-        self, name: str, max: int, min: int, start: int = None, num: int = None
+        self, name: str, max: str, min: str, start: int = None, num: int = None
     ) -> Awaitable:
         """
         Return the reversed lexicographical range of values from sorted set
@@ -3205,7 +3205,7 @@ class Redis:
         """Remove member ``values`` from sorted set ``name``"""
         return self.execute_command("ZREM", name, *values)
 
-    def zremrangebylex(self, name: str, min: int, max: int) -> Awaitable:
+    def zremrangebylex(self, name: str, min: str, max: str) -> Awaitable:
         """
         Remove all elements in the sorted set ``name`` between the
         lexicographical range specified by ``min`` and ``max``.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Fix min, max args of `Z*LEX*` to str

This is still wrong (they can be any encodable value), but it's less
wrong than `int`. Leaving making them less wrong for a more generic
cleanup of annotations (see #1008).

## Are there changes in behavior for the user?

No run-time changes.

## Related issue number

#1008

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is `<Name> <Surname>`.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the [`CHANGES/`](../tree/master/CHANGES) folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example:
   `Fix issue with non-ascii contents in doctest text files.`
