### PR TITLE
add __await__ for Pipeline class

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -43,6 +43,7 @@ Michael Käufl
 Nickolai Novik
 Oleg Butuzov
 Oleksandr Tykhonruk
+Pat Buxton
 Pau Freixes
 Paul Becotte
 Paul Colomiets

--- a/README.md
+++ b/README.md
@@ -44,14 +44,14 @@ Benchmarks can be found here:
 ## Contribute
 
 -   Issue Tracker: <https://github.com/aio-libs/aioredis/issues>
--   Google Group: <https://groups.google.com/forum/>\#!forum/aio-libs
+-   Google Group: <https://groups.google.com/g/aio-libs>
 -   Gitter: <https://gitter.im/aio-libs/Lobby>
 -   Source Code: <https://github.com/aio-libs/aioredis>
--   Contributor's guide: devel
+-   Contributor's guide: [devel](docs/devel.md)
 
 Feel free to file an issue or make pull request if you find any bugs or
 have some suggestions for library improvement.
 
 ## License
 
-The aioredis is offered under a [MIT License](license.md).
+The aioredis is offered under a [MIT License](LICENSE).

--- a/aioredis/client.py
+++ b/aioredis/client.py
@@ -4260,6 +4260,9 @@ class Pipeline(Redis):  # lgtm [py/init-calls-subclass]
     async def __aexit__(self, exc_type, exc_value, traceback):
         await self.reset()
 
+    def __await__(self):
+        return self.async_self().__await__()
+
     def __del__(self):
         try:
             loop = asyncio.get_event_loop()
@@ -4277,6 +4280,9 @@ class Pipeline(Redis):  # lgtm [py/init-calls-subclass]
     def __bool__(self):
         """Pipeline instances should always evaluate to True"""
         return True
+
+    async def async_self(self):
+        return self
 
     async def reset(self):
         self.command_stack = []

--- a/aioredis/connection.py
+++ b/aioredis/connection.py
@@ -404,7 +404,7 @@ class PythonParser(BaseParser):
             length = int(response)
             if length == -1:
                 return None
-            response = [(await self.read_response()) for i in range(length)]
+            response = [(await self.read_response()) for _ in range(length)]
         if isinstance(response, bytes):
             response = self.encoder.decode(response)
         return response
@@ -743,7 +743,7 @@ class Connection:
         # if a client_name is given, set it
         if self.client_name:
             await self.send_command("CLIENT", "SETNAME", self.client_name)
-            if str_if_bytes(self.read_response()) != "OK":
+            if str_if_bytes(await self.read_response()) != "OK":
                 raise ConnectionError("Error setting client name")
 
         # if a database is specified, switch to it


### PR DESCRIPTION
### TLDR:
without the fix this example:
```
my_key: str = "test_1"
async with redis_client.pipeline() as pipe:
    await pipe.watch(my_key)
    pipe.multi()
    await pipe.set(my_key, 0)
    await pipe.execute()
```
fails with something like this:
```
....
  File "aioredis/client.py", line 879, in initialize
AttributeError: 'Pipeline' object has no attribute 'single_connection_client'
```
### Little bit more details:
The pipeline (pipe) is redis-py's implementation of redis transaction (https://redis.io/topics/transactions).
In terms of aioredis implementation:
`Pipeline `is a child class of `Redis `class
When you try run `pipe.set()` you actually run method from parent (Redis)
inside of this parent's method (pipe.set()) special function `execute_command()` is executed 
This `execute_command()` is overridden in child `Pipeline `and looks something like this:
```
def execute_command(bla):
        if bla:
            return self.immediate_execute_command()
        return self.pipeline_execute_command()
```
The problem, is that `immediate_execute_command `is async function (async def ...) and `pipeline_execute_command `is NOT (def ...).
Developers didn't wanted to have inconsistancy in returns (sometimes awaitable, sometimes just value), so decided to make `pipeline_execute_command `to return self, so when you execute await `pipe.set() `you actually execute _await_. But await is not defined in child class (Pipeline), therefor parent's (Redis's) method executed, which in turn `executes self.initialize()` which reference `self.single_connection_client` which is not defined in child subclass (Pipeline).