### PR TITLE
Bring back py.typed

### DIFF
--- a/CHANGES/1009.misc
+++ b/CHANGES/1009.misc
@@ -1,1 +1,0 @@
-Temporarily remove py.typed because there are errors in the type annotations.

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ setup(
     extras_require={
         "hiredis": 'hiredis>=1.0; implementation_name=="cpython"',
     },
+    package_data={"aioredis": ["py.typed"]},
     python_requires=">=3.6",
     include_package_data=True,
 )


### PR DESCRIPTION
## What do these changes do?

It was initially removed in #1009, because the type annotations had many
flaws, but a number of PRs have improved that situation.

## Are there changes in behavior for the user?

mypy will now type-check use of aioredis again.

## Related issue number

Closes #1008.

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is `<Name> <Surname>`.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the [`CHANGES/`](../tree/master/CHANGES) folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example:
   `Fix issue with non-ascii contents in doctest text files.`

No unit tests because aioredis isn't even trying to be internally mypy-clean yet. I removed the CHANGES file for #1009 (which this is reverting) rather than adding a new one,which will probably make the timeline linter a bit unhappy - not sure if that's the right approach.