### PR TITLE
Set socket_connect_timeout

### DIFF
--- a/CHANGES/1060.bugfix
+++ b/CHANGES/1060.bugfix
@@ -1,1 +1,1 @@
-Set socket_connect_timeout in UnixDomainSocketConnection.
+Set socket_connect_timeout in UnixDomainSocketConnection. Change `_connect` in UnixDomainSocketConnection to use socket_connect_timeout instead of socket_timeout.

--- a/CHANGES/1060.bugfix
+++ b/CHANGES/1060.bugfix
@@ -1,1 +1,1 @@
-St socket_connect_timeout in UnixDomainSocketConnection.
+Set socket_connect_timeout in UnixDomainSocketConnection.

--- a/CHANGES/1060.bugfix
+++ b/CHANGES/1060.bugfix
@@ -1,0 +1,1 @@
+St socket_connect_timeout in UnixDomainSocketConnection.

--- a/aioredis/connection.py
+++ b/aioredis/connection.py
@@ -1042,6 +1042,7 @@ class UnixDomainSocketConnection(Connection):  # lgtm [py/missing-call-to-init]
         username: str = None,
         password: str = None,
         socket_timeout: float = None,
+        socket_connect_timeout: float = None,
         encoding: str = "utf-8",
         encoding_errors: str = "strict",
         decode_responses: bool = False,
@@ -1058,6 +1059,7 @@ class UnixDomainSocketConnection(Connection):  # lgtm [py/missing-call-to-init]
         self.client_name = client_name
         self.password = password
         self.socket_timeout = socket_timeout
+        self.socket_connect_timeout = socket_connect_timeout or socket_timeout or None
         self.retry_on_timeout = retry_on_timeout
         self.health_check_interval = health_check_interval
         self.next_health_check = -1

--- a/aioredis/connection.py
+++ b/aioredis/connection.py
@@ -1081,7 +1081,7 @@ class UnixDomainSocketConnection(Connection):  # lgtm [py/missing-call-to-init]
         return pieces
 
     async def _connect(self):
-        async with async_timeout.timeout(self.socket_timeout):
+        async with async_timeout.timeout(self.socket_connect_timeout):
             reader, writer = await asyncio.open_unix_connection(path=self.path)
         self._reader = reader
         self._writer = writer

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -3,6 +3,7 @@ from unittest import mock
 
 import pytest
 
+from aioredis.connection import UnixDomainSocketConnection
 from aioredis.exceptions import InvalidResponse
 from aioredis.utils import HIREDIS_AVAILABLE
 
@@ -19,3 +20,10 @@ async def test_invalid_response(r):
         with pytest.raises(InvalidResponse) as cm:
             await parser.read_response()
     assert str(cm.value) == "Protocol Error: %r" % raw
+
+
+@pytest.mark.asyncio
+async def test_socket_param_regression(r):
+    """A regression test for issue #1060"""
+    conn = UnixDomainSocketConnection()
+    await conn.disconnect() == True


### PR DESCRIPTION
Adds the parameter `socket_connect_timeout` to
UnixDomainSocketConnection and sets it.

As a subclass of `Connection`, this class's `disconnect()` method
expects a `socket_connect_timeout` property. We now accept that as a
parameter and set it correctly.

fixes #1060

<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is `<Name> <Surname>`.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the [`CHANGES/`](../tree/master/CHANGES) folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example:
   `Fix issue with non-ascii contents in doctest text files.`
