### PR TITLE
async-concurrent-safe PubSub

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,8 @@ devel: aioredis.egg-info init-hooks
 		-r tests/requirements.txt \
 		-r docs/requirements.txt \
 		bumpversion \
-		wheel
+		wheel \
+		mypy
 
 aioredis.egg-info:
 	pip install -Ue .

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -615,6 +615,11 @@ class TestPubSubTasks:
     async def test_subscribe_with_tasks_succeeds(self, r):
         p = r.pubsub()
         asyncio.create_task(p.subscribe("foo"))
-        assert await wait_for_message(p, timeout=2) == make_message(
-            "subscribe", "foo", 1
+        asyncio.create_task(p.subscribe("bar"))
+        messages = list(
+            filter(
+                lambda d: d is not None,
+                [await wait_for_message(p, timeout=3) for _ in range(2)],
+            )
         )
+        assert sorted(m["channel"] for m in messages) == [b"bar", b"foo"]

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -614,6 +614,7 @@ class TestPubSubRun:
 class TestPubSubTasks:
     async def test_subscribe_with_tasks_succeeds(self, r):
         p = r.pubsub()
-        await p.subscribe("foo")
         asyncio.create_task(p.subscribe("foo"))
-        assert await wait_for_message(p) == make_message("subscribe", "foo", 1)
+        assert await wait_for_message(p, timeout=2) == make_message(
+            "subscribe", "foo", 1
+        )

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -609,3 +609,11 @@ class TestPubSubRun:
             except asyncio.CancelledError:
                 pass
         assert str(e) == "error"
+
+
+class TestPubSubTasks:
+    async def test_subscribe_with_tasks_succeeds(self, r):
+        p = r.pubsub()
+        await p.subscribe("foo")
+        asyncio.create_task(p.subscribe("foo"))
+        assert await wait_for_message(p) == make_message("subscribe", "foo", 1)

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -132,48 +132,48 @@ class TestPubSubSubscribeUnsubscribe:
         self, p, sub_type, unsub_type, sub_func, unsub_func, keys
     ):
 
-        assert p.subscribed is False
+        assert await p.subscribed() is False
         await sub_func(keys[0])
         # we're now subscribed even though we haven't processed the
         # reply from the server just yet
-        assert p.subscribed is True
+        assert await p.subscribed() is True
         assert await wait_for_message(p) == make_message(sub_type, keys[0], 1)
         # we're still subscribed
-        assert p.subscribed is True
+        assert await p.subscribed() is True
 
         # unsubscribe from all channels
         await unsub_func()
         # we're still technically subscribed until we process the
         # response messages from the server
-        assert p.subscribed is True
+        assert await p.subscribed() is True
         assert await wait_for_message(p) == make_message(unsub_type, keys[0], 0)
         # now we're no longer subscribed as no more messages can be delivered
         # to any channels we were listening to
-        assert p.subscribed is False
+        assert await p.subscribed() is False
 
         # subscribing again flips the flag back
         await sub_func(keys[0])
-        assert p.subscribed is True
+        assert await p.subscribed() is True
         assert await wait_for_message(p) == make_message(sub_type, keys[0], 1)
 
         # unsubscribe again
         await unsub_func()
-        assert p.subscribed is True
+        assert await p.subscribed() is True
         # subscribe to another channel before reading the unsubscribe response
         await sub_func(keys[1])
-        assert p.subscribed is True
+        assert await p.subscribed() is True
         # read the unsubscribe for key1
         assert await wait_for_message(p) == make_message(unsub_type, keys[0], 0)
         # we're still subscribed to key2, so subscribed should still be True
-        assert p.subscribed is True
+        assert await p.subscribed() is True
         # read the key2 subscribe message
         assert await wait_for_message(p) == make_message(sub_type, keys[1], 1)
         await unsub_func()
         # haven't read the message yet, so we're still subscribed
-        assert p.subscribed is True
+        assert await p.subscribed() is True
         assert await wait_for_message(p) == make_message(unsub_type, keys[1], 0)
         # now we're finally unsubscribed
-        assert p.subscribed is False
+        assert await p.subscribed() is False
 
     async def test_subscribe_property_with_channels(self, r):
         kwargs = make_subscribe_test_data(r.pubsub(), "channel")
@@ -193,12 +193,12 @@ class TestPubSubSubscribeUnsubscribe:
             (p.punsubscribe, "f*"),
         )
 
-        assert p.subscribed is False
+        assert await p.subscribed() is False
         for func, channel in checks:
             assert await func(channel) is None
-            assert p.subscribed is True
+            assert await p.subscribed() is True
             assert await wait_for_message(p) is None
-        assert p.subscribed is False
+        assert await p.subscribed() is False
 
     async def test_ignore_individual_subscribe_messages(self, r):
         p = r.pubsub()
@@ -210,13 +210,13 @@ class TestPubSubSubscribeUnsubscribe:
             (p.punsubscribe, "f*"),
         )
 
-        assert p.subscribed is False
+        assert await p.subscribed() is False
         for func, channel in checks:
             assert await func(channel) is None
-            assert p.subscribed is True
+            assert await p.subscribed() is True
             message = await wait_for_message(p, ignore_subscribe_messages=True)
             assert message is None
-        assert p.subscribed is False
+        assert await p.subscribed() is False
 
     async def test_sub_unsub_resub_channels(self, r):
         kwargs = make_subscribe_test_data(r.pubsub(), "channel")
@@ -234,11 +234,11 @@ class TestPubSubSubscribeUnsubscribe:
         await sub_func(key)
         await unsub_func(key)
         await sub_func(key)
-        assert p.subscribed is True
+        assert await p.subscribed() is True
         assert await wait_for_message(p) == make_message(sub_type, key, 1)
         assert await wait_for_message(p) == make_message(unsub_type, key, 0)
         assert await wait_for_message(p) == make_message(sub_type, key, 1)
-        assert p.subscribed is True
+        assert await p.subscribed() is True
 
     async def test_sub_unsub_all_resub_channels(self, r):
         kwargs = make_subscribe_test_data(r.pubsub(), "channel")
@@ -256,11 +256,11 @@ class TestPubSubSubscribeUnsubscribe:
         await sub_func(key)
         await unsub_func()
         await sub_func(key)
-        assert p.subscribed is True
+        assert await p.subscribed() is True
         assert await wait_for_message(p) == make_message(sub_type, key, 1)
         assert await wait_for_message(p) == make_message(unsub_type, key, 0)
         assert await wait_for_message(p) == make_message(sub_type, key, 1)
-        assert p.subscribed is True
+        assert await p.subscribed() is True
 
 
 class TestPubSubMessages:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Locks sections of `PubSub` that change the subscribed channels. Adds an `asyncio.Event` and uses it to signal when at least one subscription has succeeded.

These changes allow users to subscribe to channels with `PubSub` using `Task`s, as outlined in #1053.

**NOTE**: I'm not sure about these changes yet. I'd opening this early in draft mode for feedback/ideas.

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

Yes, `PubSub.subscribed` changes from a property to a coroutine.

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

#1053 

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is `<Name> <Surname>`.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the [`CHANGES/`](../tree/master/CHANGES) folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example:
   `Fix issue with non-ascii contents in doctest text files.`
