### PR TITLE
Use ContextVar to track Task-local Lock token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-      - '[0-9].[0-9]+'  # matches to backport branches, e.g. 3.6
+      - '[0-9].[0-9]+'  # matches to backport branches, e.g. 3.7
     tags: [ 'v*' ]
   pull_request:
     branches:
@@ -56,14 +56,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        pyver: [3.6, 3.7, 3.8, 3.9, pypy3]
+        pyver: [3.7, 3.8, 3.9, pypy3]
         uvloop: [uvloop, no-uvloop]
         redis: [5.0.10, 6.2.4]
         exclude:
         - { pyver: pypy3, uvloop: uvloop, os: ubuntu-latest, redis: 5.0.10 }
         - { pyver: pypy3, uvloop: uvloop, os: ubuntu-latest, redis: 6.2.4 }
-        - { pyver: 3.6, uvloop: uvloop, os: ubuntu-latest, redis: 5.0.10 }
-        - { pyver: 3.6, uvloop: uvloop, os: ubuntu-latest, redis: 6.2.4 }
       fail-fast: false
     services:
       redis:

--- a/CHANGES/1040.bugfix
+++ b/CHANGES/1040.bugfix
@@ -1,0 +1,1 @@
+Use ContextVar to track Task-local Lock token.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -8,6 +8,7 @@ Aider Ibragimov
 Alan Christianson
 Alexander Shorin
 Aliaksei Urbanski
+Andrew Brookins
 Andrew Chen Wang
 Andrew Svetlov
 Anton Ilyushenkov <driverx>


### PR DESCRIPTION
## What do these changes do?

The Lock implementation in redis-py uses thread-local storage
so that multiple threads using the same Lock instance can
acquire the Lock from each other.

Thread-local storage ensures that each thread sees a different
token value.

Thread-local storage does not apply in the Task-based concurrency
that asyncio programs use. To achieve a similar effect, we need
to embed a ContextVar instance within each Lock and store the Lock
instance's token within the ContextVar instance. This allows every
Task that uses the same Lock instance to see a different token.

Thus, if both Task A and Task B refer to Lock 1, Task A can "acquire"
Lock 1 and block Task B from acquiring the same Lock until Task A
"releases" the Lock.

NOTE: The Python documentation suggests only storing ContextVar
instances in the top-level module scope due to issues around
garbage collection. That won't work in the current design of
Lock. For lack of a better alternative, and to preserve the
original design of Lock taken from redis-py, we have created
instances of ContextVar within instances of Lock.

## Are there changes in behavior for the user?

Different from redis-py:

1. Users who wish to refer to a Lock's token must do so using `lock.local_token.get()`.
2. We have to drop support for Python 3.6 to use ContextVar. Python 3.6 is EOL 23 Dec 2021. 🤷 

## Related issue number

Fixes #1040.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes [NOTE: The internal state of the Lock, being the token, is not something current documentation discusses]
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is `<Name> <Surname>`.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the [`CHANGES/`](../tree/master/CHANGES) folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example:
   `Fix issue with non-ascii contents in doctest text files.`
