### PR TITLE
Restore mkdocs-autorefs version

### DIFF
--- a/CHANGES/1084.bugfix
+++ b/CHANGES/1084.bugfix
@@ -1,0 +1,1 @@
+Restore mkdocs-autorefs to version 0.2.1 to remain compatible with mkdocstrings.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 mkdocs==1.2.2
-mkdocs-autorefs==0.3.0
+mkdocs-autorefs==0.2.1
 mkdocs-awesome-pages-plugin==2.5.0
 mkdocs-material==7.2.1
 mkdocs-material-extensions==1.0.1


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Dependabot upgraded a dependency that doesn't appear to have a security vulnerability, and the other tools in our docs toolchain require the older version. This PR restores the older version.

## Are there changes in behavior for the user?

No.

## Related issue number

Fixes #1084 

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is `<Name> <Surname>`.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the [`CHANGES/`](../tree/master/CHANGES) folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example:
   `Fix issue with non-ascii contents in doctest text files.`
