### PR TITLE
Allow concurrent coroutines sending commands over a single connection

### DIFF
--- a/CHANGES/1105.bugfix
+++ b/CHANGES/1105.bugfix
@@ -1,0 +1,1 @@
+Allow concurrent coroutines sending commands over a single connection

--- a/aioredis/connection.py
+++ b/aioredis/connection.py
@@ -609,6 +609,7 @@ class Connection:
         )
         self._connect_callbacks: List[ConnectCallbackT] = []
         self._buffer_cutoff = 6000
+        self._lock = asyncio.Lock()
 
     def __repr__(self):
         repr_args = ",".join((f"{k}={v}" for k, v in self.repr_pieces()))
@@ -850,8 +851,9 @@ class Connection:
     async def read_response(self):
         """Read the response from a previously sent command"""
         try:
-            async with async_timeout.timeout(self.socket_timeout):
-                response = await self._parser.read_response()
+            async with self._lock:
+                async with async_timeout.timeout(self.socket_timeout):
+                    response = await self._parser.read_response()
         except asyncio.TimeoutError:
             await self.disconnect()
             raise TimeoutError(f"Timeout reading from {self.host}:{self.port}")

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,3 +1,4 @@
+import asyncio
 from typing import TYPE_CHECKING
 from unittest import mock
 
@@ -27,3 +28,9 @@ async def test_socket_param_regression(r):
     """A regression test for issue #1060"""
     conn = UnixDomainSocketConnection()
     await conn.disconnect() == True
+
+
+@pytest.mark.asyncio
+async def test_can_run_concurrent_commands(r):
+    assert await r.ping() is True
+    assert all(await asyncio.gather(*(r.ping() for _ in range(10))))


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?
This is to allow running concurrent coroutines over a single connection. This is not a replacement for the ConnectionPool.

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?
No

<!-- Outline any notable behaviour for the end users. -->

## Related issue number
1105

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [X] I think the code is well written
- [X] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is `<Name> <Surname>`.
  * Please keep alphabetical order, the file is sorted by names.
- [X] Add a new news fragment into the [`CHANGES/`](../tree/master/CHANGES) folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example:
   `Fix issue with non-ascii contents in doctest text files.`
