### PR TITLE
Auto-reconnect on `PubSub.get_message`

### DIFF
--- a/aioredis/client.py
+++ b/aioredis/client.py
@@ -4031,7 +4031,7 @@ class PubSub:
 
         await self.check_health()
 
-        if not block and not await conn.can_read(timeout=timeout):
+        if not block and not await self._execute(conn, conn.can_read, timeout=timeout):
             return None
         response = await self._execute(conn, conn.read_response)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Auto-reconnect in `PubSub.get_message` when Redis connection gets interrupted.

## Are there changes in behavior for the user?

No.

## Related issue number

Fixes #1130 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist  *I don't think new tests are necessary*
- [x] Documentation reflects the changes  *No changes in documented behavior*
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is `<Name> <Surname>`.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the [`CHANGES/`](../tree/master/CHANGES) folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example:
   `Fix issue with non-ascii contents in doctest text files.`
