### PR TITLE
Fix the parameter order of zrevrangebyscore()

### DIFF
--- a/CHANGES/1136.bugfix
+++ b/CHANGES/1136.bugfix
@@ -1,0 +1,1 @@
+Fix zrevrangebyscore(): pass correct order of MAX and MIN parameters to Redis. Also, change the order of the parameters in zrevrangebyscore() to match the order expected by Redis (max followed by min).

--- a/aioredis/client.py
+++ b/aioredis/client.py
@@ -3336,8 +3336,8 @@ class Redis:
     def zrevrangebyscore(
         self,
         name: KeyT,
-        min: ZScoreBoundT,
         max: ZScoreBoundT,
+        min: ZScoreBoundT,
         start: Optional[int] = None,
         num: Optional[int] = None,
         withscores: bool = False,
@@ -3357,7 +3357,7 @@ class Redis:
         """
         if (start is not None and num is None) or (num is not None and start is None):
             raise DataError("``start`` and ``num`` must both be specified")
-        pieces: List[EncodableT] = ["ZREVRANGEBYSCORE", name, min, max]
+        pieces: List[EncodableT] = ["ZREVRANGEBYSCORE", name, max, min]
         if start is not None and num is not None:
             pieces.extend([b"LIMIT", start, num])
         if withscores:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
Fixes the ZREVRANGEBYSCORE command call in the zrevrangebyscore() method to the correct order: max, min.

To better reflect the command, this change also adjusts the order of the parameters to the zrevrangebyscore() method to max, min.

fixes #1136

## Are there changes in behavior for the user?

*The parameter order of zrevrangebyscore() is now max, min.*

## Related issue number

#1136 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is `<Name> <Surname>`.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the [`CHANGES/`](../tree/master/CHANGES) folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example:
   `Fix issue with non-ascii contents in doctest text files.`
