### PR TITLE
Fix typing of socket_keepalive_options to follow stdlib's setsockopt()

### DIFF
--- a/CHANGES/1141.bugfix
+++ b/CHANGES/1141.bugfix
@@ -1,0 +1,1 @@
+Fix type annotation of `socket_keepalive_options` arguments when creating connections and clients

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -35,6 +35,7 @@ Ivan Antonyuck
 James Hilliard
 Jan Špaček
 Jeff Moser
+Joongi Kim <achimnol>
 Kyrylo Dehtyarenko
 Leonid Shvechikov
 Manuel Miranda

--- a/aioredis/client.py
+++ b/aioredis/client.py
@@ -824,7 +824,7 @@ class Redis:
         socket_timeout: Optional[float] = None,
         socket_connect_timeout: Optional[float] = None,
         socket_keepalive: Optional[bool] = None,
-        socket_keepalive_options: Optional[Dict[str, Any]] = None,
+        socket_keepalive_options: Optional[Mapping[int, Union[int, bytes]]] = None,
         connection_pool: Optional[ConnectionPool] = None,
         unix_socket_path: Optional[str] = None,
         encoding: str = "utf-8",

--- a/aioredis/connection.py
+++ b/aioredis/connection.py
@@ -573,7 +573,7 @@ class Connection:
         socket_timeout: Optional[float] = None,
         socket_connect_timeout: Optional[float] = None,
         socket_keepalive: bool = False,
-        socket_keepalive_options: Optional[dict] = None,
+        socket_keepalive_options: Optional[Mapping[int, Union[int, bytes]]] = None,
         socket_type: int = 0,
         retry_on_timeout: bool = False,
         encoding: str = "utf-8",


### PR DESCRIPTION
## What do these changes do?

Fix the type annotation for `socket_keepalive_options` to follow the standard library's
`socket.Socket.setsockopt()` method.

## Are there changes in behavior for the user?

No behavioral changes but this will fix bogus errors with static type checks.

## Related issue number

resolves #1141

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is `<Name> <Surname>`.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the [`CHANGES/`](../tree/master/CHANGES) folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example:
   `Fix issue with non-ascii contents in doctest text files.`
