### PR TITLE
Fix deprecation warnings

### DIFF
--- a/CHANGES/1190.misc
+++ b/CHANGES/1190.misc
@@ -1,0 +1,1 @@
+Fix deprecation warnings

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -38,6 +38,7 @@ Jeff Moser
 Kyrylo Dehtyarenko
 Leonid Shvechikov
 Manuel Miranda
+Marat Sharafutdinov
 Marek Szapiel
 Marijn Giesen
 Martin <the-panda>

--- a/aioredis/client.py
+++ b/aioredis/client.py
@@ -28,7 +28,7 @@ from typing import (
     cast,
 )
 
-from aioredis.compat import Protocol, TypedDict
+from aioredis.compat import Protocol, TypedDict, create_task_or_run, get_event_loop
 from aioredis.connection import (
     Connection,
     ConnectionPool,
@@ -1056,11 +1056,7 @@ class Redis:
 
     def __del__(self):
         try:
-            loop = asyncio.get_event_loop()
-            if loop.is_running():
-                loop.create_task(self.close())
-            else:
-                loop.run_until_complete(self.close())
+            create_task_or_run(self.close())
         except Exception:
             pass
 
@@ -4064,7 +4060,7 @@ class PubSub:
 
         if (
             conn.health_check_interval
-            and asyncio.get_event_loop().time() > conn.next_health_check
+            and get_event_loop().time() > conn.next_health_check
         ):
             await conn.send_command(
                 "PING", self.HEALTH_CHECK_MESSAGE, check_health=False
@@ -4351,11 +4347,7 @@ class Pipeline(Redis):  # lgtm [py/init-calls-subclass]
 
     def __del__(self):
         try:
-            loop = asyncio.get_event_loop()
-            if loop.is_running():
-                loop.create_task(self.reset())
-            else:
-                loop.run_until_complete(self.reset())
+            create_task_or_run(self.reset())
             super().__del__()
         except Exception:
             pass

--- a/aioredis/compat.py
+++ b/aioredis/compat.py
@@ -2,6 +2,7 @@ import asyncio
 import sys
 
 if sys.version_info >= (3, 7):
+
     def get_event_loop():
         return asyncio.get_running_loop()
 
@@ -10,7 +11,10 @@ if sys.version_info >= (3, 7):
             asyncio.create_task(coro)
         except RuntimeError:
             asyncio.run(coro)
+
+
 else:
+
     def get_event_loop():
         return asyncio.get_event_loop()
 
@@ -20,6 +24,7 @@ else:
             loop.create_task(coro)
         else:
             loop.run_until_complete(coro)
+
 
 if sys.version_info >= (3, 8):
     from typing import Protocol, TypedDict

--- a/aioredis/compat.py
+++ b/aioredis/compat.py
@@ -1,4 +1,25 @@
+import asyncio
 import sys
+
+if sys.version_info >= (3, 7):
+    def get_event_loop():
+        return asyncio.get_running_loop()
+
+    def create_task_or_run(coro):
+        try:
+            asyncio.create_task(coro)
+        except RuntimeError:
+            asyncio.run(coro)
+else:
+    def get_event_loop():
+        return asyncio.get_event_loop()
+
+    def create_task_or_run(coro):
+        loop = asyncio.get_event_loop()
+        if loop.is_running():
+            loop.create_task(coro)
+        else:
+            loop.run_until_complete(coro)
 
 if sys.version_info >= (3, 8):
     from typing import Protocol, TypedDict

--- a/aioredis/lock.py
+++ b/aioredis/lock.py
@@ -4,6 +4,7 @@ import uuid
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Awaitable, NoReturn, Optional, Union
 
+from aioredis.compat import get_event_loop
 from aioredis.exceptions import LockError, LockNotOwnedError
 
 if TYPE_CHECKING:
@@ -185,7 +186,7 @@ class Lock:
         object with the default encoding. If a token isn't specified, a UUID
         will be generated.
         """
-        loop = asyncio.get_event_loop()
+        loop = get_event_loop()
         sleep = self.sleep
         if token is None:
             token = uuid.uuid1().hex.encode()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

These changes save code from warnings. [asyncio.get_event_loop](https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.get_event_loop) is deprecated since Python version 3.10.

## Are there changes in behavior for the user?

No.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [X] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is `<Name> <Surname>`.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the [`CHANGES/`](../tree/master/CHANGES) folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example:
   `Fix issue with non-ascii contents in doctest text files.`
