### PR TITLE
Fix buffer is closed error when using PythonParser class

### DIFF
--- a/CHANGES/1212.bugfix
+++ b/CHANGES/1212.bugfix
@@ -1,0 +1,1 @@
+Fix buffer is closed error when using PythonParser class

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -38,6 +38,7 @@ Jeff Moser
 Joongi Kim <achimnol>
 Kyrylo Dehtyarenko
 Leonid Shvechikov
+Maksim Novikov
 Manuel Miranda
 Marek Szapiel
 Marijn Giesen

--- a/aioredis/connection.py
+++ b/aioredis/connection.py
@@ -373,7 +373,7 @@ class PythonParser(BaseParser):
     def on_connect(self, connection: "Connection"):
         """Called when the stream connects"""
         self._stream = connection._reader
-        if self._buffer is None or self._stream is None:
+        if self._stream is None:
             raise RedisError("Buffer is closed.")
 
         self._buffer = SocketBuffer(

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -4,17 +4,15 @@ from unittest import mock
 
 import pytest
 
-from aioredis.connection import UnixDomainSocketConnection
+from aioredis.connection import PythonParser, UnixDomainSocketConnection
 from aioredis.exceptions import InvalidResponse
-from aioredis.utils import HIREDIS_AVAILABLE
-
-if TYPE_CHECKING:
-    from aioredis.connection import PythonParser
 
 
-@pytest.mark.skipif(HIREDIS_AVAILABLE, reason="PythonParser only")
 @pytest.mark.asyncio
-async def test_invalid_response(r):
+@pytest.mark.parametrize("create_redis", [(True, PythonParser)], indirect=True)
+async def test_invalid_response(create_redis):
+    r = await create_redis()
+
     raw = b"x"
     parser: "PythonParser" = r.connection._parser
     with mock.patch.object(parser._buffer, "readline", return_value=raw):

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,11 +1,12 @@
 import asyncio
 from typing import TYPE_CHECKING
-from unittest import mock
 
 import pytest
 
 from aioredis.connection import PythonParser, UnixDomainSocketConnection
 from aioredis.exceptions import InvalidResponse
+
+from .compat import mock
 
 
 @pytest.mark.asyncio
@@ -14,8 +15,10 @@ async def test_invalid_response(create_redis):
     r = await create_redis()
 
     raw = b"x"
+    readline_mock = mock.AsyncMock(return_value=raw)
+
     parser: "PythonParser" = r.connection._parser
-    with mock.patch.object(parser._buffer, "readline", return_value=raw):
+    with mock.patch.object(parser._buffer, "readline", readline_mock):
         with pytest.raises(InvalidResponse) as cm:
             await parser.read_response()
     assert str(cm.value) == "Protocol Error: %r" % raw


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?
Fix issue when the exception is raised on connection initialization in PythonParser
Add parametrization for both parsers to all tests using redis client to catch these errors in the future

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?
No
<!-- Outline any notable behaviour for the end users. -->

## Related issue number
#1212
#1114
<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is `<Name> <Surname>`.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the [`CHANGES/`](../tree/master/CHANGES) folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example:
   `Fix issue with non-ascii contents in doctest text files.`
