### PR TITLE
Fix typing on evalsha keys_and_args argument

### DIFF
--- a/CHANGES/1214.bugfix
+++ b/CHANGES/1214.bugfix
@@ -1,0 +1,1 @@
+Fix typing on evalsha keys_and_args argument

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -28,6 +28,7 @@ Dmitry Vasilishin <dmvass>
 Evgenii Morozov <emorozov>
 Federico Jaite <fedej>
 Hugo <hugovk>
+Ian Good
 Ihor Gorobets
 Ihor Liubymov
 Ilya Samartsev

--- a/aioredis/client.py
+++ b/aioredis/client.py
@@ -3576,7 +3576,7 @@ class Redis:
         """
         return self.execute_command("EVAL", script, numkeys, *keys_and_args)
 
-    def evalsha(self, sha: str, numkeys: int, *keys_and_args: str) -> Awaitable:
+    def evalsha(self, sha: str, numkeys: int, *keys_and_args: EncodableT) -> Awaitable:
         """
         Use the ``sha`` to execute a Lua script already registered via EVAL
         or SCRIPT LOAD. Specify the ``numkeys`` the script will touch and the


### PR DESCRIPTION

<!-- Thank you for your contribution! -->

## What do these changes do?

Resolve the restrictive typing on evalsha keys_and_args argument.

## Are there changes in behavior for the user?

No, this change only affects typing hints.

## Related issue number

Fix #1214

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is `<Name> <Surname>`.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the [`CHANGES/`](../tree/master/CHANGES) folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example:
   `Fix issue with non-ascii contents in doctest text files.`
