### PR TITLE
[RFC] Use callback based asyncio.Protocol for communication

### DIFF
--- a/aioredis/client.py
+++ b/aioredis/client.py
@@ -1078,28 +1078,31 @@ class Redis:
         command_name = args[0]
         conn = self.connection or await pool.get_connection(command_name, **options)
         try:
-            await conn.send_command(*args)
-            return await self.parse_response(conn, command_name, **options)
+            resp = await conn.send_command(*args)
+            return await self.parse_response(resp, command_name, **options)
+        except ResponseError:
+            if EMPTY_RESPONSE in options:
+                return options[EMPTY_RESPONSE]
+            raise
         except (ConnectionError, TimeoutError) as e:
             await conn.disconnect()
             if not (conn.retry_on_timeout and isinstance(e, TimeoutError)):
                 raise
-            await conn.send_command(*args)
-            return await self.parse_response(conn, command_name, **options)
+            resp = await conn.send_command(*args)
+            return await self.parse_response(resp, command_name, **options)
         finally:
             if not self.connection:
                 await pool.release(conn)
 
     async def parse_response(
-        self, connection: Connection, command_name: Union[str, bytes], **options
+        self, response, command_name: Union[str, bytes], **options
     ):
         """Parses a response from the Redis server"""
-        try:
-            response = await connection.read_response()
-        except ResponseError:
+        if isinstance(response, ResponseError):
             if EMPTY_RESPONSE in options:
                 return options[EMPTY_RESPONSE]
-            raise
+            raise response from None
+
         if command_name in self.response_callbacks:
             # Mypy bug: https://github.com/python/mypy/issues/10977
             command_name = cast(str, command_name)
@@ -4431,8 +4434,8 @@ class Pipeline(Redis):  # lgtm [py/init-calls-subclass]
             self.connection = conn
         conn = cast(Connection, conn)
         try:
-            await conn.send_command(*args)
-            return await self.parse_response(conn, command_name, **options)
+            resp = await conn.send_command(*args)
+            return await self.parse_response(resp, command_name, **options)
         except (ConnectionError, TimeoutError) as e:
             await conn.disconnect()
             # if we were already watching a variable, the watch is no longer
@@ -4452,8 +4455,8 @@ class Pipeline(Redis):  # lgtm [py/init-calls-subclass]
             # retry_on_timeout is set, this is a TimeoutError and we are not
             # already WATCHing any variables. retry the command.
             try:
-                await conn.send_command(*args)
-                return self.parse_response(conn, command_name, **options)
+                resp = await conn.send_command(*args)
+                return self.parse_response(resp, command_name, **options)
             except (ConnectionError, TimeoutError):
                 # a subsequent failure should simply be raised
                 await self.reset()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Attempt to refactor connection code to avoid unnecessary polling and waiting. 

When testing this branch use a single connection client, connection pool has some locking around it that need to be ironed out.
But performance wise pool doesn't actually help, for [simplistic client](https://github.com/m-novikov/aioredis-benchmarks/blob/main/aioredis_benchmarks/baseline.py)
```python
async with Redis(connection_pool=pool).client() as redis:
    ...
```

Also this PR uses only `HiredisParser` because `feed` parser API is needed to conveniently use with protocol callbacks.
In case this approach is feasible `PythonParser` would also need to be refactored(rewritten?) to support `feed`.

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

#1208

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is `<Name> <Surname>`.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the [`CHANGES/`](../tree/master/CHANGES) folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example:
   `Fix issue with non-ascii contents in doctest text files.`
