### PR TITLE
Add test markers to allow more granularity selecting tests

### DIFF
--- a/CHANGES/1219.misc
+++ b/CHANGES/1219.misc
@@ -1,0 +1,1 @@
+Add pytest markers for parsers and connection types

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,3 +7,11 @@ issue_format = "#{issue}"
 underlines = ["", ""]
 template = ".towncrier.md.jinja"
 title_format = "## {version} - ({project_date})"
+
+[tool.pytest.ini_options]
+markers = [
+    "hiredis_parser: mark a test as using hiredis parser",
+    "python_parser: mark a test as using python parser",
+    "connection_pool: mark a test as using connection_pool client",
+    "single_connection: mark a test as using single connection client",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -132,26 +132,38 @@ def skip_unless_arch_bits(arch_bits):
 
 @pytest.fixture(
     params=[
-        (True, PythonParser),
-        (False, PythonParser),
+        pytest.param(
+            (True, PythonParser),
+            marks=[pytest.mark.python_parser, pytest.mark.single_connection],
+            id="single-connection-python-parser",
+        ),
+        pytest.param(
+            (False, PythonParser),
+            marks=[pytest.mark.python_parser, pytest.mark.connection_pool],
+            id="pool-python-parser",
+        ),
         pytest.param(
             (True, HiredisParser),
-            marks=pytest.mark.skipif(
-                not HIREDIS_AVAILABLE, reason="hiredis is not installed"
-            ),
+            marks=[
+                pytest.mark.skipif(
+                    not HIREDIS_AVAILABLE, reason="hiredis is not installed"
+                ),
+                pytest.mark.hiredis_parser,
+                pytest.mark.single_connection,
+            ],
+            id="single-connection-hiredis",
         ),
         pytest.param(
             (False, HiredisParser),
-            marks=pytest.mark.skipif(
-                not HIREDIS_AVAILABLE, reason="hiredis is not installed"
-            ),
+            marks=[
+                pytest.mark.skipif(
+                    not HIREDIS_AVAILABLE, reason="hiredis is not installed"
+                ),
+                pytest.mark.hiredis_parser,
+                pytest.mark.connection_pool,
+            ],
+            id="pool-hiredis",
         ),
-    ],
-    ids=[
-        "single-python-parser",
-        "pool-python-parser",
-        "single-hiredis",
-        "pool-hiredis",
     ],
 )
 def create_redis(request, event_loop):


### PR DESCRIPTION
To speed up testing add markers for selecting/deselecting following cases:
* hiredis_parser
* python_parser
* connection pool
* single connection

<!-- Thank you for your contribution! -->

## What do these changes do?

Following up on #1213 as the current test suite could take longer to run, it makes sense to have more granularity when selecting tests.

It is probably most convenient to use for deselecting tests. For example:
```bash
pytest -k "not python_parser and not connection_pool" -v
```

## Are there changes in behavior for the user?

No changes to behavior

## Related issue number

#1213 

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is `<Name> <Surname>`.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the [`CHANGES/`](../tree/master/CHANGES) folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example:
   `Fix issue with non-ascii contents in doctest text files.`
