### PR TITLE
Fix typing on blpop (etc) timeout argument

### DIFF
--- a/CHANGES/1224.bugfix
+++ b/CHANGES/1224.bugfix
@@ -1,0 +1,1 @@
+Fix typing on blpop (etc) timeout argument

--- a/aioredis/client.py
+++ b/aioredis/client.py
@@ -65,6 +65,7 @@ GroupT = _StringLikeT  # Consumer group
 ConsumerT = _StringLikeT  # Consumer name
 StreamIdT = Union[int, _StringLikeT]
 ScriptTextT = _StringLikeT
+TimeoutSecT = Union[int, float, _StringLikeT]
 # Mapping is not covariant in the key type, which prevents
 # Mapping[_StringLikeT, X from accepting arguments of type Dict[str, X]. Using
 # a TypeVar instead of a Union allows mappings with any of the permitted types
@@ -2124,7 +2125,7 @@ class Redis:
         return self.execute_command("UNLINK", *names)
 
     # LIST COMMANDS
-    def blpop(self, keys: KeysT, timeout: int = 0) -> Awaitable:
+    def blpop(self, keys: KeysT, timeout: TimeoutSecT = 0) -> Awaitable:
         """
         LPOP a value off of the first non-empty list
         named in the ``keys`` list.
@@ -2137,7 +2138,7 @@ class Redis:
         """
         return self.execute_command("BLPOP", *list_or_args(keys, (timeout,)))
 
-    def brpop(self, keys: KeysT, timeout: int = 0) -> Awaitable:
+    def brpop(self, keys: KeysT, timeout: TimeoutSecT = 0) -> Awaitable:
         """
         RPOP a value off of the first non-empty list
         named in the ``keys`` list.
@@ -2150,7 +2151,7 @@ class Redis:
         """
         return self.execute_command("BRPOP", *list_or_args(keys, (timeout,)))
 
-    def brpoplpush(self, src: KeyT, dst: KeyT, timeout: int = 0) -> Awaitable:
+    def brpoplpush(self, src: KeyT, dst: KeyT, timeout: TimeoutSecT = 0) -> Awaitable:
         """
         Pop a value off the tail of ``src``, push it on the head of ``dst``
         and then return it.
@@ -3140,7 +3141,7 @@ class Redis:
         options = {"withscores": True}
         return self.execute_command("ZPOPMIN", name, *args, **options)
 
-    def bzpopmax(self, keys: KeysT, timeout: int = 0) -> Awaitable:
+    def bzpopmax(self, keys: KeysT, timeout: TimeoutSecT = 0) -> Awaitable:
         """
         ZPOPMAX a value off of the first non-empty sorted set
         named in the ``keys`` list.
@@ -3154,7 +3155,7 @@ class Redis:
         parsed_keys = list_or_args(keys, (timeout,))
         return self.execute_command("BZPOPMAX", *parsed_keys)
 
-    def bzpopmin(self, keys: KeysT, timeout: int = 0) -> Awaitable:
+    def bzpopmin(self, keys: KeysT, timeout: TimeoutSecT = 0) -> Awaitable:
         """
         ZPOPMIN a value off of the first non-empty sorted set
         named in the ``keys`` list.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import argparse
 import asyncio
 import random
 from distutils.version import StrictVersion
+from typing import Callable, TypeVar
 from urllib.parse import urlparse
 
 import pytest
@@ -24,6 +25,9 @@ REDIS_6_VERSION = "5.9.0"
 
 REDIS_INFO = {}
 default_redis_url = "redis://localhost:6379/9"
+
+_DecoratedTest = TypeVar("_DecoratedTest", bound="Callable")
+_TestDecorator = Callable[[_DecoratedTest], _DecoratedTest]
 
 
 # Taken from python3.9
@@ -111,19 +115,19 @@ def pytest_sessionstart(session):
     REDIS_INFO["arch_bits"] = arch_bits
 
 
-def skip_if_server_version_lt(min_version):
+def skip_if_server_version_lt(min_version: str) -> _TestDecorator:
     redis_version = REDIS_INFO["version"]
     check = StrictVersion(redis_version) < StrictVersion(min_version)
     return pytest.mark.skipif(check, reason=f"Redis version required >= {min_version}")
 
 
-def skip_if_server_version_gte(min_version):
+def skip_if_server_version_gte(min_version: str) -> _TestDecorator:
     redis_version = REDIS_INFO["version"]
     check = StrictVersion(redis_version) >= StrictVersion(min_version)
     return pytest.mark.skipif(check, reason=f"Redis version required < {min_version}")
 
 
-def skip_unless_arch_bits(arch_bits):
+def skip_unless_arch_bits(arch_bits: int) -> _TestDecorator:
     return pytest.mark.skipif(
         REDIS_INFO["arch_bits"] != arch_bits,
         reason=f"server is not {arch_bits}-bit",


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Improves typing on [blpop](https://redis.io/commands/blpop)'s *timeout* argument, which is a number of seconds (not milliseconds) and allows decimal precision:

> The timeout argument is interpreted as a double value specifying the maximum number of seconds to block. A timeout of zero can be used to block indefinitely.

Other blocking `b*` methods were updated similarly. I also fixed some low-hanging mypy errors under `tests/`.

## Are there changes in behavior for the user?

No change in behavior, only type hint changes.

## Related issue number

N/A

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is `<Name> <Surname>`.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the [`CHANGES/`](../tree/master/CHANGES) folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example:
   `Fix issue with non-ascii contents in doctest text files.`
