### PR TITLE
Fix lock is not instantiated on UnixDomainSocketConnection init (#1249)

### DIFF
--- a/CHANGES/1249.bugfix
+++ b/CHANGES/1249.bugfix
@@ -1,0 +1,1 @@
+Instantiate lock on UnixDomainSocketConnection init.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -22,6 +22,7 @@ Chao Guo <jeffguorg>
 Contributors
 Daniil Kozhanov
 David Francos
+David Testé
 Dima Kit
 Dima Kruk
 Dmitry Vasilishin <dmvass>

--- a/aioredis/connection.py
+++ b/aioredis/connection.py
@@ -1122,6 +1122,7 @@ class UnixDomainSocketConnection(Connection):  # lgtm [py/missing-call-to-init]
         self._parser = parser_class(socket_read_size=socket_read_size)
         self._connect_callbacks = []
         self._buffer_cutoff = 6000
+        self._lock = asyncio.Lock()
 
     def repr_pieces(self) -> Iterable[Tuple[str, Union[str, int]]]:
         pieces = [


### PR DESCRIPTION
Fixes #1249

<!-- Thank you for your contribution! -->

## What do these changes do?

It instantiate an `asyncio.Lock` in `UnixDomainSocketConnection.__init__` . This is done to reflect changes that occurred in #1106 .

## Are there changes in behavior for the user?

Commands over Unix socket to Redis now succeed.

## Related issue number

#1249

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is `<Name> <Surname>`.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the [`CHANGES/`](../tree/master/CHANGES) folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example:
   `Fix issue with non-ascii contents in doctest text files.`
