### PR TITLE
Add auto_close_connection_pool and close_connection_pool in Redis.close()

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,21 +31,21 @@ jobs:
     - name: Cache PyPI
       uses: actions/cache@v2.1.6
       with:
-        key: ${{ runner.os }}-pip-lint-${{ hashFiles('**/requirements.txt') }}
+        key: pip-lint-${{ hashFiles('**/requirements.txt') }}
         path: ~/.cache/pip
         restore-keys: |
-            ${{ runner.os }}-pip-lint-
+            pip-lint-
     - name: Install dependencies
       uses: py-actions/py-dependency-install@v3
       with:
         path: tests/requirements.txt
     - name: Run mypy
       run: |
+        pip install -U setuptools
         pip install -r tests/requirements-mypy.txt
         mypy
     - name: Run linter
       run: |
-        pip install -U setuptools
         make lint
     - name: Prepare twine checker
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,10 @@ jobs:
     - name: Cache PyPI
       uses: actions/cache@v2.1.6
       with:
-        key: pip-lint-${{ hashFiles('**/requirements.txt') }}
+        key: ${{ runner.os }}-pip-lint-${{ hashFiles('**/requirements.txt') }}
         path: ~/.cache/pip
         restore-keys: |
-            pip-lint-
+            ${{ runner.os }}-pip-lint-
     - name: Install dependencies
       uses: py-actions/py-dependency-install@v3
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
         mypy
     - name: Run linter
       run: |
+        pip install -U setuptools
         make lint
     - name: Prepare twine checker
       run: |

--- a/CHANGES/1256.feature
+++ b/CHANGES/1256.feature
@@ -1,0 +1,1 @@
+Add auto_close_connection_pool for Redis-created connection pools, not manually created pools

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -14,6 +14,83 @@ from .test_pubsub import wait_for_message
 pytestmark = pytest.mark.asyncio
 
 
+class TestRedisAutoReleaseConnectionPool:
+    @pytest.fixture
+    async def r(self, create_redis) -> aioredis.Redis:
+        """This is necessary since r and r2 create ConnectionPools behind the scenes"""
+        r = await create_redis()
+        r.auto_close_connection_pool = True
+        yield r
+
+    @staticmethod
+    def get_total_connected_connections(pool):
+        return len(pool._available_connections) + len(pool._in_use_connections)
+
+    @staticmethod
+    async def create_two_conn(r: aioredis.Redis):
+        if not r.single_connection_client:  # Single already initialized connection
+            r.connection = await r.connection_pool.get_connection("_")
+        return await r.connection_pool.get_connection("_")
+
+    @staticmethod
+    def has_no_connected_connections(pool: aioredis.ConnectionPool):
+        return not any(
+            x.is_connected
+            for x in pool._available_connections + list(pool._in_use_connections)
+        )
+
+    async def test_auto_disconnect_redis_created_pool(self, r: aioredis.Redis):
+        new_conn = await self.create_two_conn(r)
+        assert new_conn != r.connection
+        assert self.get_total_connected_connections(r.connection_pool) == 2
+        await r.close()
+        assert self.has_no_connected_connections(r.connection_pool)
+
+    async def test_do_not_auto_disconnect_redis_created_pool(self, r2: aioredis.Redis):
+        assert r2.auto_close_connection_pool is False, (
+            "The connection pool should not be disconnected as a manually created "
+            "connection pool was passed in in conftest.py"
+        )
+        new_conn = await self.create_two_conn(r2)
+        assert self.get_total_connected_connections(r2.connection_pool) == 2
+        await r2.close()
+        assert r2.connection_pool._in_use_connections == {new_conn}
+        assert new_conn.is_connected
+        assert len(r2.connection_pool._available_connections) == 1
+        assert r2.connection_pool._available_connections[0].is_connected
+
+    async def test_auto_release_override_true_manual_created_pool(
+        self, r: aioredis.Redis
+    ):
+        assert r.auto_close_connection_pool is True, "This is from the class fixture"
+        await self.create_two_conn(r)
+        await r.close()
+        assert self.get_total_connected_connections(r.connection_pool) == 2, (
+            "The connection pool should not be disconnected as a manually created "
+            "connection pool was passed in in conftest.py"
+        )
+        assert self.has_no_connected_connections(r.connection_pool)
+
+    @pytest.mark.parametrize("auto_close_conn_pool", [True, False])
+    async def test_close_override(self, r: aioredis.Redis, auto_close_conn_pool):
+        r.auto_close_connection_pool = auto_close_conn_pool
+        await self.create_two_conn(r)
+        await r.close(close_connection_pool=True)
+        assert self.has_no_connected_connections(r.connection_pool)
+
+    @pytest.mark.parametrize("auto_close_conn_pool", [True, False])
+    async def test_negate_auto_close_client_pool(
+        self, r: aioredis.Redis, auto_close_conn_pool
+    ):
+        r.auto_close_connection_pool = auto_close_conn_pool
+        new_conn = await self.create_two_conn(r)
+        await r.close(close_connection_pool=False)
+        assert not self.has_no_connected_connections(r.connection_pool)
+        assert r.connection_pool._in_use_connections == {new_conn}
+        assert r.connection_pool._available_connections[0].is_connected
+        assert self.get_total_connected_connections(r.connection_pool) == 2
+
+
 class DummyConnection(Connection):
     description_format = "DummyConnection<>"
 


### PR DESCRIPTION
Signed-off-by: Andrew-Chen-Wang <acwangpython@gmail.com>

<!-- Thank you for your contribution! -->

## What do these changes do?

Add auto_close_connection_pool for Redis-created connection pools, not manually created pools. Adds close_connection_pool in Redis.close() for manual override on whether to close connection pool or not.


<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

Yes, connection pools automatically disconnect. The user may still disconnect all connections from the connection pools themselves, but it is safe to remove their code for doing so. It is also safe to leave it as is.
<!-- Outline any notable behaviour for the end users. -->

## Related issue number

Fixes #1103 
<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [X] I think the code is well written
- [X] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [X] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is `<Name> <Surname>`.
  * Please keep alphabetical order, the file is sorted by names.
- [X] Add a new news fragment into the [`CHANGES/`](../tree/master/CHANGES) folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example:
   `Fix issue with non-ascii contents in doctest text files.`
