### PR TITLE
Support for async callbacks

### DIFF
--- a/CHANGES/1284.feature
+++ b/CHANGES/1284.feature
@@ -1,0 +1,1 @@
+Using coroutines as callbacks is now possible.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -63,6 +63,7 @@ Sean Stewart <seandstewart>
 Sergey Miletskiy
 SeungHyun Hwang
 Stanislau Arkhipenka
+Stephan Meier
 Taku Fukada
 Taras Voinarovskyi
 Thanos Lefteris

--- a/aioredis/client.py
+++ b/aioredis/client.py
@@ -74,7 +74,7 @@ TimeoutSecT = Union[int, float, _StringLikeT]
 AnyKeyT = TypeVar("AnyKeyT", bytes, str, memoryview)
 AnyFieldT = TypeVar("AnyFieldT", bytes, str, memoryview)
 AnyChannelT = ChannelT
-PubSubHandler = Callable[[Dict[str, str]], None]
+PubSubHandler = Callable[[Dict[str, str]], Awaitable[None]]
 
 SYM_EMPTY = b""
 EMPTY_RESPONSE = "EMPTY_RESPONSE"

--- a/aioredis/client.py
+++ b/aioredis/client.py
@@ -4157,7 +4157,7 @@ class PubSub:
     async def listen(self) -> AsyncIterator:
         """Listen for messages on channels this client has been subscribed to"""
         while self.subscribed:
-            response = self.handle_message(await self.parse_response(block=True))
+            response = await self.handle_message(await self.parse_response(block=True))
             if response is not None:
                 yield response
 
@@ -4173,7 +4173,7 @@ class PubSub:
         """
         response = await self.parse_response(block=False, timeout=timeout)
         if response:
-            return self.handle_message(response, ignore_subscribe_messages)
+            return await self.handle_message(response, ignore_subscribe_messages)
         return None
 
     def ping(self, message=None) -> Awaitable:
@@ -4183,7 +4183,7 @@ class PubSub:
         message = "" if message is None else message
         return self.execute_command("PING", message)
 
-    def handle_message(self, response, ignore_subscribe_messages=False):
+    async def handle_message(self, response, ignore_subscribe_messages=False):
         """
         Parses a pub/sub message. If the channel or pattern was subscribed to
         with a message handler, the handler is invoked instead of a parsed
@@ -4232,7 +4232,10 @@ class PubSub:
             else:
                 handler = self.channels.get(message["channel"], None)
             if handler:
-                handler(message)
+                if inspect.iscoroutinefunction(handler):
+                    await handler(message)
+                else:
+                    handler(message)
                 return None
         elif message_type != "pong":
             # this is a subscribe/unsubscribe message. ignore if we don't

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -270,6 +270,9 @@ class TestPubSubMessages:
     def message_handler(self, message):
         self.message = message
 
+    async def async_message_handler(self, message):
+        self.message = message
+
     async def test_published_message_to_channel(self, r):
         p = r.pubsub()
         await p.subscribe("foo")
@@ -306,6 +309,14 @@ class TestPubSubMessages:
     async def test_channel_message_handler(self, r):
         p = r.pubsub(ignore_subscribe_messages=True)
         await p.subscribe(foo=self.message_handler)
+        assert await wait_for_message(p) is None
+        assert await r.publish("foo", "test message") == 1
+        assert await wait_for_message(p) is None
+        assert self.message == make_message("message", "foo", "test message")
+
+    async def test_channel_async_message_handler(self, r):
+        p = r.pubsub(ignore_subscribe_messages=True)
+        await p.subscribe(foo=self.async_message_handler)
         assert await wait_for_message(p) is None
         assert await r.publish("foo", "test message") == 1
         assert await wait_for_message(p) is None

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -271,7 +271,7 @@ class TestPubSubMessages:
         self.message = message
 
     async def async_message_handler(self, message):
-        self.message = message
+        self.async_message = message
 
     async def test_published_message_to_channel(self, r):
         p = r.pubsub()
@@ -320,7 +320,18 @@ class TestPubSubMessages:
         assert await wait_for_message(p) is None
         assert await r.publish("foo", "test message") == 1
         assert await wait_for_message(p) is None
+        assert self.async_message == make_message("message", "foo", "test message")
+
+    async def test_channel_sync_async_message_handler(self, r):
+        p = r.pubsub(ignore_subscribe_messages=True)
+        await p.subscribe(foo=self.message_handler)
+        await p.subscribe(bar=self.async_message_handler)
+        assert await wait_for_message(p) is None
+        assert await r.publish("foo", "test message") == 1
+        assert await r.publish("bar", "test message 2") == 1
+        assert await wait_for_message(p) is None
         assert self.message == make_message("message", "foo", "test message")
+        assert self.async_message == make_message("message", "bar", "test message 2")
 
     async def test_pattern_message_handler(self, r):
         p = r.pubsub(ignore_subscribe_messages=True)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
As mentioned in #1235 you can't use coroutines as custom callbacks. This patch tries to fix that.
## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->
There shouldn't be any changes for the users as sync callbacks are still supported.
## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
#1235 
## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is `<Name> <Surname>`.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the [`CHANGES/`](../tree/master/CHANGES) folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example:
   `Fix issue with non-ascii contents in doctest text files.`
