### PR TITLE
Add `items` to signature of `hset`

### DIFF
--- a/aioredis/client.py
+++ b/aioredis/client.py
@@ -3497,16 +3497,19 @@ class Redis:
         key: Optional[FieldT] = None,
         value: Optional[EncodableT] = None,
         mapping: Optional[Mapping[AnyFieldT, EncodableT]] = None,
+        items: Optional[List[Union[FieldT, Optional[EncodableT]]]] = None,
     ) -> Awaitable:
         """
         Set ``key`` to ``value`` within hash ``name``,
-        ``mapping`` accepts a dict of key/value pairs that that will be
+        ``mapping`` accepts a dict of key/value pairs that will be
+        added to hash ``name``.
+        ``items`` accepts a list of key/value pairs that will be
         added to hash ``name``.
         Returns the number of fields that were added.
         """
-        if key is None and not mapping:
+        if key is None and not mapping and not items:
             raise DataError("'hset' with no key value pairs")
-        items: List[Union[FieldT, Optional[EncodableT]]] = []
+        items: List[Union[FieldT, Optional[EncodableT]]] = items or []
         if key is not None:
             items.extend((key, value))
         if mapping:

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1809,6 +1809,17 @@ class TestRedisCommands:
         assert await r.hget("b", "1") == b"1"
         assert await r.hget("b", "2") == b"2"
         assert await r.hget("b", "foo") == b"bar"
+        
+    async def test_hset_with_items(self, r: aioredis.Redis):
+        await r.hset("a", items=["1", 1, "2", 2, "3", 3]
+        assert await r.hget("a", "1") == b"1"
+        assert await r.hget("a", "2") == b"2"
+        assert await r.hget("a", "3") == b"3"
+
+        await r.hset("b", "foo", "bar", items=["1", 1, "2", 2])
+        assert await r.hget("b", "1") == b"1"
+        assert await r.hget("b", "2") == b"2"
+        assert await r.hget("b", "foo") == b"bar"
 
     async def test_hset_without_data(self, r: aioredis.Redis):
         with pytest.raises(exceptions.DataError):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

It allows passing `items` (key/value pairs as a list) to `hset`.

## Are there changes in behavior for the user?

No regression, just new functionality.

## Related issue number

https://github.com/aio-libs/aioredis-py/issues/1299

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is `<Name> <Surname>`.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the [`CHANGES/`](../tree/master/CHANGES) folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example:
   `Fix issue with non-ascii contents in doctest text files.`
